### PR TITLE
기능 추가: hikari 적용(실패)

### DIFF
--- a/board/build.gradle
+++ b/board/build.gradle
@@ -23,7 +23,6 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.bgee.log4jdbc-log4j2:log4jdbc-log4j2-jdbc4.1:1.16'

--- a/board/src/main/resources/application.properties
+++ b/board/src/main/resources/application.properties
@@ -3,11 +3,6 @@ spring.datasource.url=jdbc:log4jdbc:oracle:thin:@localhost:1521:xe
 spring.datasource.username=c##spring_test
 spring.datasource.password=test
 
-#spring.datasource.url=jdbc:oracle:thin:@localhost:1521:xe
-#spring.datasource.driver-class-name=oracle.jdbc.OracleDriver
-#spring.datasource.username=c##jun9
-#spring.datasource.password=0320
-
 spring.jpa.properties.hibernate.show_sql=true
 spring.jpa.properties.hibernate.format_sql=true
 logging.level.org.hibernate.SQL=DEBUG


### PR DESCRIPTION
## 기능 추가 사항
 - 공식 문서를 통해 hikari를 적용하려고 했지만 계속해서 Failed to load ApplicationContext가 발생하고 오류를 고치려고 시도를 했지만 결국 고치지 못해 hikari CP 적용은 뒤로 미루기로 했습니다.
 - hikari를 적용하기 위해 사용했던 implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'을 제거했습니다. 그리고 implementation 'org.springframework.boot:spring-boot-starter-data-jpa' 만 있어도 hikari를 사용할 수 있습니다.