### PR TITLE
기능 개선: 게시글 목록에서 번호를 고유 ID로 변경

### DIFF
--- a/board/src/main/resources/templates/board/list.html
+++ b/board/src/main/resources/templates/board/list.html
@@ -79,7 +79,7 @@
 					json.forEach((obj, idx) => {
 						html += `
 							<tr>
-    							<td>${json.length - idx}</td>
+    							<td>${obj.id}</td>
     							<td class="text-left">
     								<a href="javascript: void(0);">${obj.title}</a>
     							</td>


### PR DESCRIPTION
## 기능 개선 사항
 - 글 번호를 나타내는 방식을 리스트의 길이에서 인덱스를 빼는 방식으로 하지 않고 게시글의 아이디를 사용하도록 변경했습니다.
 - 관련 이슈: #67