### PR TITLE
기능 추가: 게시글 삭제 기능 추가

### DIFF
--- a/board/src/main/java/com/jk/board/controller/BoardApiController.java
+++ b/board/src/main/java/com/jk/board/controller/BoardApiController.java
@@ -2,12 +2,14 @@ package com.jk.board.controller;
 
 import java.util.List;
 
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.jk.board.dto.BoardRequest;
@@ -36,8 +38,8 @@ public class BoardApiController {
 	 * 게시글 리스트 조회
 	 */
 	@GetMapping("/boards")
-	public List<BoardResponse> findBoards() {
-		return boardService.findBoards();
+	public List<BoardResponse> findBoards(@RequestParam final boolean isDeleted) {
+		return boardService.findAllBoardsByIsDeleted(isDeleted);
 	}
 
 	/*
@@ -46,5 +48,13 @@ public class BoardApiController {
 	@PatchMapping("/boards/{id}")
 	public Long updateBoard(@PathVariable final Long id, @RequestBody final BoardRequest boardRequest) {
 		return boardService.updateBoard(id, boardRequest);
+	}
+	
+	/*
+	 * 게시글 삭제
+	 */
+	@DeleteMapping("/boards/{id}")
+	public Long deleteBoard(@PathVariable final Long id) {
+		return boardService.delete(id);
 	}
 }

--- a/board/src/main/java/com/jk/board/entity/Board.java
+++ b/board/src/main/java/com/jk/board/entity/Board.java
@@ -71,4 +71,8 @@ public class Board {
         this.writer = writer;
         this.modifiedDate = LocalDateTime.now();
     }
+	
+	public void delete() {
+		this.isDeleted = true;
+	}
 }

--- a/board/src/main/java/com/jk/board/repository/BoardRepository.java
+++ b/board/src/main/java/com/jk/board/repository/BoardRepository.java
@@ -1,9 +1,16 @@
 package com.jk.board.repository;
 
+import java.util.List;
+
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.jk.board.entity.Board;
 
 public interface BoardRepository extends JpaRepository<Board, Long> {
 	
+	/*
+	 * 게시글 리스트 조회 (삭제되지 않은)
+	 */
+	List<Board> findAllByIsDeleted(final boolean isDeleted, final Sort sort);
 }

--- a/board/src/main/java/com/jk/board/service/BoardService.java
+++ b/board/src/main/java/com/jk/board/service/BoardService.java
@@ -37,9 +37,19 @@ public class BoardService {
 	/*
 	 * 게시글 리스트 조회
 	 */
-	public List<BoardResponse> findBoards() {
+	public List<BoardResponse> findAllBoards() {
 		Sort sort = Sort.by(Direction.DESC, "id", "createdDate");
 		List<Board> list = boardRepository.findAll(sort);
+		
+		return list.stream().map(BoardResponse::new).toList();
+	}
+	
+	/*
+	 * 게시글 리스트 조회 (삭제되지 않은)
+	 */
+	public List<BoardResponse> findAllBoardsByIsDeleted(final boolean isDeleted) {
+		Sort sort = Sort.by(Direction.DESC, "id", "createdDate");
+		List<Board> list = boardRepository.findAllByIsDeleted(isDeleted, sort);
 		
 		return list.stream().map(BoardResponse::new).toList();
 	}
@@ -48,9 +58,20 @@ public class BoardService {
 	 * 게시글 수정
 	 */
 	@Transactional
-	public Long updateBoard(final Long id, BoardRequest boardRequest) {
+	public Long updateBoard(final Long id, final BoardRequest boardRequest) {
 		Board board = boardRepository.findById(id).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
 		board.update(boardRequest.getTitle(), boardRequest.getContent(), boardRequest.getWriter());
+		
+		return id;
+	}
+	
+	/*
+	 * 게시글 삭제
+	 */
+	@Transactional
+	public Long delete(final Long id) {
+		Board board = boardRepository.findById(id).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
+		board.delete();
 		
 		return id;
 	}

--- a/board/src/main/resources/templates/board/list.html
+++ b/board/src/main/resources/templates/board/list.html
@@ -66,7 +66,7 @@
 		 */
 		function findAll() {
 
-			fetch('/api/boards').then(response => {
+			fetch('/api/boards?isDeleted=false').then(response => {
 				if (response.ok) {
    					return response.json();
 				}

--- a/board/src/main/resources/templates/board/write.html
+++ b/board/src/main/resources/templates/board/write.html
@@ -84,7 +84,7 @@
 						title: form.title.value,
 						writer: form.writer.value,
 						content: form.content.value,
-						idDeleted: 0
+						idDeleted: false
 					};
 
 					fetch('/api/boards', {


### PR DESCRIPTION
## 기능 추가 사항
 - Board Entity에 isDeleted를 true로 변경하는 메서드를 추가했습니다.
 - Board Repository에 findAllByIsDeleted를 추가해 isDeleted 값에 따른 조회 기능을 추가했습니다.
 - Board Service에 해당 아이디 Board를 찾고 isDeleted 값을 변경하는 delete 메서드를 추가했습니다.
 - Board Service에 삭제되지 않은 게시글 리스트만 조회하는 findAllBoardsByIsDeleted 메서드를 추가했습니다.
 - Board API Controller에 게시글 삭제 기능을 하는 deleteBoard 메서드를 추가했습니다.
 - Board API Controller의 findBoards 메서드에 매개변수를 추가하고 Board Service의 findAllBoardsByIsDeleted 메서드를 사용하도록 변경했습니다.
 - list.html 파일의 findAll() 함수에서 fetch 부분에 ?isDeleted=false를 추가했습니다.
 - 관련 이슈: #69

## 기타 사항
 - **코드 리팩토링**
     - write.html 파일에서 writeBoard() 함수의 isDeleted 값을 0에서 false로 변경하였습니다.
     - Board Service의 updateBoard 메서드의 매개변수 boardRequest에 final 키워드를 추가했습니다.
     - Board Service의 findBoards() 메서드를 findAllBoards() 메서로 변경해 가독성을 증가시켰습니다.