### PR TITLE
버그 수정: 게시글 삭제 후 뒤로 가기

### DIFF
--- a/board/src/main/resources/templates/board/list.html
+++ b/board/src/main/resources/templates/board/list.html
@@ -57,6 +57,11 @@
 		 * 페이지 로딩 시점에 실행되는 함수
 		 */
 		window.onload = () => {
+			window.onpageshow = function (event) {
+				if (event.persisted || (window.performance && window.performance.navigation.type == 2)) {
+					location.reload();
+				}
+			}
 
 			findAll();
 		}

--- a/board/src/main/resources/templates/board/view.html
+++ b/board/src/main/resources/templates/board/view.html
@@ -34,7 +34,7 @@
     	</form>
 
     	<div class="btn_wrap text-center">
-    		<a href="javascript: void(0);" onclick="goList();" class="btn btn-default waves-effect waves-light">뒤로가기</a>
+    		<a th:href="@{/board/list}" class="btn btn-default waves-effect waves-light">뒤로가기</a>
     		<a href="javascript: void(0);" class="btn btn-primary waves-effect waves-light">수정하기</a>
     		<button type="button" onclick="deleteBoard();" class="btn btn-danger waves-effect waves-light">삭제하기</button>
     	</div>
@@ -76,10 +76,10 @@
 		}
 		
 		/*
-		* 뒤로가기
+		* 게시글 리스트 이동
 		*/
 		function goList() {
-			location.href = '/board/list';
+			location.replace('/board/list');
 		}
 		
 		/*


### PR DESCRIPTION
## 기능 추가 사항
 - 다시 접근해서는 안되는 페이지나 삭제된 게시글 리스트를 제거하는 기능을 추가했습니다.
 - 관련 이슈: #31

## 테스트 결과
 - location.replace() 사용 시
     - 뒤로 가면 게시글 상세 페이지는 안보이지만 삭제된 게시글이 포함된 게시글 리스트가 보입니다.
 - location.href + history.replaceState() 사용 시 
     - 처음 뒤로 가기할 때는 보이지 않지만 두 번 뒤로갈 시 삭제된 게시글 리스트가 보입니다.
 - list.html에 뒤로 가기 이벤트 감지 후 새로 고침 사용 시
     - 뒤로 가기로 접근 시 이벤트 처리에 의해 자동으로 새로고침 돼서 올바른 결과를 주지만 깜박임으로 인해 사용자 경험이 불편할 수도 있고, 새로 고침으로 인해 서버 리소스를 더 잡아 먹을 수 있습니다.
 - **결론**
     - 우선 올바른 정보를 주는 이벤트 감지 후 새로 고침을 우선적으로 사용하고, 추후에 새로 고침 방식이 아닌 다른 방법을 통해

## 기타 수정 사항
 - view.html의 findBoard(), deleteBoard() 함수 뒤로 갔을 때 페이지에 접근하면 안되기 때문에 goList() 함수를 location.replace()로 변경했습니다.
 - 뒤로 가기 a 태그는 원래 goList()를 사용하다가 따로 th:href로 분리를 진행했습니다.