### PR TITLE
기능 추가: 이전 페이저 정보 유지 기능 추가

### DIFF
--- a/board/src/main/resources/templates/board/list.html
+++ b/board/src/main/resources/templates/board/list.html
@@ -61,13 +61,8 @@
 		 * 페이지 로딩 시점에 실행되는 함수
 		 */
 		window.onload = () => {
-			window.onpageshow = function (event) {
-				if (event.persisted || (window.performance && window.performance.navigation.type == 2)) {
-					location.reload();
-				}
-			}
-
-			findAll(1);
+			setQueryStringParams();
+			findAll();
 			addEnterSearchEvent();
 		}
 		
@@ -81,6 +76,26 @@
 							findAll(1);
 						}
 					});
+		}
+		
+		/*
+		* 쿼리 스트링 파라미터 세팅
+		*/
+		function setQueryStringParams() {
+			if (!location.search) {
+				return false;
+			}
+			
+			const form = document.getElementById('searchForm');
+			
+			// 쿼리 스트링은 key1=value1&key2=value2로 보통 작성되지만
+			// JavaScript에서 URLSearchParams 객체의 forEach 메소드를 사용할 때는
+			// (value, key) 순으로 매개 변수를 받는 게 컨벤션이다.
+			new URLSearchParams(location.search).forEach((value, key) => {
+				if (form[key]) {
+					form[key].value = value;
+				}
+			});
 		}
 
 		/*
@@ -106,6 +121,9 @@
 		 * 게시글 리스트 조회
 		 */
 		function findAll(currentPage) {
+			const currentPageParam = Number(new URLSearchParams(location.search).get('currentPage'));
+			currentPage = (currentPage) ? currentPage : ((currentPageParam) ? currentPageParam : 1);
+			
 			const form = document.getElementById('searchForm');
 			const params = {
 					currentPage: currentPage, 


### PR DESCRIPTION
## 기능 추가 사항
 - setQueryStringParams 함수를 추가했습니다. - History API를 통해 만들어진 URL을 저장합니다. - 페이지를 로딩할 때 findAll 함수를 통해 게시글 리스트를 만들기 전에 페이지를 저장하기 위해서 사용합니다.
 - findAll 함수에 현재 페이지를 저장하는 로직을 추가합니다.
 - 관련 이슈: #95

## 기타 추가 사항
 - 그 전에 뒤로 가기를 했을 때에 정보 동기화를 위해 새로고침을 강제로 진행했던 기능이 정상적으로 작동되지 않아 삭제했습니다.