### PR TITLE
버그 수정: 게시글 번호 게시글 ID로 수정

### DIFF
--- a/board/src/main/resources/templates/board/list.html
+++ b/board/src/main/resources/templates/board/list.html
@@ -150,7 +150,7 @@
 				response.list.forEach((obj, idx) => {
 					html += `
 							<tr>
-	    						<td>${startRecord--}</td>
+	    						<td>${obj.id}</td>
 	    						<td class="text-left">
 	    							<a href="javascript: void(0);" onclick="goView(${obj.id})">${obj.title}</a>
 	    						</td>


### PR DESCRIPTION
## 버그 수정 사항
 - findAll 함수의 list부분의 startRecord--를 obj.id로 변경했습니다.
 - 관련 이슈: #103