### PR TITLE
기능 추가: 상세 페이지로 이전 페이저 정보 전달 기능 추가

### DIFF
--- a/board/src/main/resources/templates/board/list.html
+++ b/board/src/main/resources/templates/board/list.html
@@ -148,12 +148,11 @@
 				let startRecord = response.params.pagination.totalRecordCount - ((response.params.currentPage - 1) * response.params.recordPerPage);
 				
 				response.list.forEach((obj, idx) => {
+					const viewUrl = `/board/view/${obj.id}` + '?' + queryString;
 					html += `
 							<tr>
 	    						<td>${obj.id}</td>
-	    						<td class="text-left">
-	    							<a href="javascript: void(0);" onclick="goView(${obj.id})">${obj.title}</a>
-	    						</td>
+	    						<td class="text-left"><a href="${viewUrl}">${obj.title}</a></td>
 	    						<td>${obj.writer}</td>
 	    						<td>${obj.modifiedDate ? moment(obj.modifiedDate).format('YYYY-MM-DD HH:mm:ss') : moment(obj.createdDate).format('YYYY-MM-DD HH:mm:ss')}</td>
 	    						<td>${obj.hits}</td>
@@ -165,14 +164,7 @@
 				renderPageButtons(response.params);
 			});
 		}
-		
-		/*
-		* 게시글 상세 조회
-		*/
-		function goView(id) {
-			location.href = `/board/view/${id}`;
-		}
-		
+
 		/*
 		* 페이지 HTML 렌더링
 		*/

--- a/board/src/main/resources/templates/board/view.html
+++ b/board/src/main/resources/templates/board/view.html
@@ -34,7 +34,7 @@
     	</form>
 
     	<div class="btn_wrap text-center">
-    		<a th:href="@{/board/list}" class="btn btn-default waves-effect waves-light">뒤로가기</a>
+    		<a href="javascript: void(0);" onclick="goListWithHref();" class="btn btn-default waves-effect waves-light">뒤로가기</a>
     		<a href="javascript: void(0);" onclick="goWrite();" class="btn btn-primary waves-effect waves-light">수정하기</a>
     		<button type="button" onclick="deleteBoard();" class="btn btn-danger waves-effect waves-light">삭제하기</button>
     	</div>
@@ -71,22 +71,29 @@
 				});
 			}).catch(error => {
 				alert('게시글 정보를 찾을 수 없습니다.');
-				goList();
+				goListWithReplace();
 			});
 		}
 
 		/*
 		* 게시글 리스트 이동
 		*/
-		function goList() {
-			location.replace('/board/list');
+		function goListWithHref() {
+			location.href = '/board/list' + location.search;
+		}
+		
+		/*
+		* 예외 시 게시글 리스트 이동
+		*/
+		function goListWithReplace() {
+			location.replace('/board/list' + location.search);
 		}
 		
 		/*
 		* 수정하기
 		*/
 		function goWrite() {
-			location.href = `/board/write?id=[[ ${id} ]]`;
+			location.href = '/board/write' + location.search + `&id=[[ ${id} ]]`;
 		}
 		
 		/*
@@ -110,7 +117,7 @@
 				}
 				
 				alert('삭제되었습니다.');
-				goList();
+				goListWithReplace();
 			}).catch(error => {
 				alert('오류가 발생했습니다.')
 			});

--- a/board/src/main/resources/templates/board/write.html
+++ b/board/src/main/resources/templates/board/write.html
@@ -29,7 +29,7 @@
 				</div>
 	
 				<div class="btn_wrap text-center">
-					<a th:href="@{/board/list}" class="btn btn-default waves-effect waves-light">돌아가기</a>
+					<a href="javascript: void(0);" onclick="goListWithHref();" class="btn btn-default waves-effect waves-light">돌아가기</a>
 					<button type="button" onclick="writeBoard();" class="btn btn-primary waves-effect waves-light">저장하기</button>
 				</div>
 			</form>
@@ -44,6 +44,19 @@
 						findBoard();
 				}
 
+				/*
+				* 게시글 리스트 이동
+				*/
+				function goListWithHref() {
+					location.href ='/board/list' + location.search;
+				}
+				
+				/*
+				* 예외 시 게시글 리스트 이동
+				*/
+				function goListWithReplace() {
+					location.replace('/board/list' + location.search);
+				}
 				/*
 				 * 게시글 조회
 				 */
@@ -66,7 +79,7 @@
 						form.writer.value = json.writer;
 					}).catch(error => {
 						alert('게시글 정보를 찾을 수 없습니다.');
-						location.replace('/board/list');
+						goListWithReplace();
 					});
 				}
 				
@@ -132,7 +145,7 @@
 						}
 
 						alert('저장되었습니다.');
-						location.href = '/board/list';
+						goListWithHref();
 
 					}).catch(error => {
 						alert('오류가 발생하였습니다.');


### PR DESCRIPTION
## 기능 추가 사항
### list.html
     - 쿼리 스트링을 포함한 URL을 상세 페이지로 보내주는 기능을 추가합니다.
     - goView(id) 함수를 삭제합니다.
### view.html와 write.html
     - location.search를 통해 이동할 때 쿼리 스트링을 포함해서 이동하는 기능을 추가합니다.
     - 뒤로 가기가 가능해야 하는 경우와 불가능해야 하는 경우가 있기 때문에 함수를 분리했습니다.

 - 관련 이슈: #105