### PR TITLE
기능 추가: Board Entity와 Comment Entity의 연관관계 기능 추가

### DIFF
--- a/board/src/main/java/com/jk/board/entity/Board.java
+++ b/board/src/main/java/com/jk/board/entity/Board.java
@@ -1,12 +1,16 @@
 package com.jk.board.entity;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.SequenceGenerator;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -55,6 +59,10 @@ public class Board {
 	private LocalDateTime createdDate = LocalDateTime.now();
 	
 	private LocalDateTime modifiedDate;
+	
+	@OneToMany(mappedBy = "board", fetch = FetchType.EAGER, cascade = CascadeType.REMOVE)
+	private List<Comment> comments;
+	
 
 	@Builder
 	public Board(String title, String content, String writer, int hits, boolean isDeleted) {

--- a/board/src/main/java/com/jk/board/entity/Comment.java
+++ b/board/src/main/java/com/jk/board/entity/Comment.java
@@ -7,6 +7,8 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.SequenceGenerator;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -38,4 +40,8 @@ public class Comment {
 	private LocalDateTime createdDate = LocalDateTime.now();
 	
 	private LocalDateTime modifiedDate;
+	
+	@ManyToOne
+	@JoinColumn(name = "BOARD_ID")
+	private Board board;
 }


### PR DESCRIPTION
## 기능 추가 사항
 - **Board 클래스**
    - 하나의 게시글에 여러 개의 댓글이 있으므로, `@OneToMany` 어노테이션을 통해 연관관계를 설정합니다. 
    - 게시글 UI에서 댓글을 바로 보여주기 위해 FetchType을 EAGER로 설정합니다. 
    - 게시글이 삭제되면 댓글 또한 삭제돼야 하기 때문에 CascadeType을 ROMOVE로 설정합니다.
 - **Comment 클래스**
     - 게시글과는 반대되는 상황이므로, `@ManyToOne` 어노테이션을 통해 연관관계를 설정합니다. 
     - `@ManyToOne` 어노테이션의 기본 FetchType은 EAGER이기 때문에 따로 설정하지 않았습니다.
- 관련 이슈: #109 