### PR TITLE
Controller 추가: Comment Controller 추가

### DIFF
--- a/board/src/main/java/com/jk/board/controller/CommentApiController.java
+++ b/board/src/main/java/com/jk/board/controller/CommentApiController.java
@@ -1,0 +1,40 @@
+package com.jk.board.controller;
+
+import java.util.Optional;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.jk.board.dto.CommentRequest;
+import com.jk.board.dto.CommentResponse;
+import com.jk.board.service.CommentService;
+
+@RequestMapping("/api")
+@RestController
+public class CommentApiController {
+
+	private final CommentService commentService;
+	
+	public CommentApiController(final CommentService commentService) {
+		this.commentService = commentService;
+	}
+	
+	/*
+	 * 댓글 생성
+	 */
+	@PostMapping("/boards/{boardId}/comments")
+	public ResponseEntity<CommentResponse> writeComment(@PathVariable final Long boardId, @RequestBody final CommentRequest commentRequest) {
+		Long commentId = commentService.writeComment(boardId ,commentRequest);
+		Optional<CommentResponse> commentResponseOptional = commentService.findCommentById(commentId);
+		
+		if (commentResponseOptional.isPresent()) {
+			return ResponseEntity.ok(commentResponseOptional.get());
+		} else {
+			return ResponseEntity.notFound().build();
+		}
+	}
+}

--- a/board/src/main/java/com/jk/board/entity/Board.java
+++ b/board/src/main/java/com/jk/board/entity/Board.java
@@ -61,9 +61,9 @@ public class Board {
 	
 	private LocalDateTime modifiedDate;
 	
-	@OneToMany(mappedBy = "board", fetch = FetchType.EAGER, cascade = CascadeType.REMOVE)
-	@OrderBy("id ASC")
-	private List<Comment> comments;
+//	@OneToMany(mappedBy = "board", fetch = FetchType.EAGER, cascade = CascadeType.REMOVE)
+//	@OrderBy("id ASC")
+//	private List<Comment> comments;
 	
 	@Builder
 	public Board(String title, String content, String writer, int hits, boolean isDeleted) {

--- a/board/src/main/java/com/jk/board/entity/Comment.java
+++ b/board/src/main/java/com/jk/board/entity/Comment.java
@@ -10,6 +10,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -23,6 +24,7 @@ import lombok.NoArgsConstructor;
 		allocationSize = 1
 		)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "COMMENTS")
 @Entity
 public class Comment {
 
@@ -31,7 +33,7 @@ public class Comment {
 	@Column(name = "COMMENT_ID")
 	private Long id;
 	
-	@Column(nullable = false, columnDefinition = "CLOB")
+	@Column(name = "COMMENTS", nullable = false, columnDefinition = "CLOB")
 	private String comment;
 	
 	@Column(nullable = false)
@@ -46,9 +48,13 @@ public class Comment {
 	private LocalDateTime modifiedDate;
 	
 	@ManyToOne
-	@JoinColumn(name = "BOARD_ID")
+	@JoinColumn(name = "BOARD_ID", nullable = false)
 	private Board board;
 
+	public void setBoard(Board board) {
+		this.board = board;
+	}
+	
 	@Builder
 	public Comment(String comment, String writer, boolean isDeleted, Board board) {
 		this.comment = comment;

--- a/board/src/main/java/com/jk/board/service/CommentService.java
+++ b/board/src/main/java/com/jk/board/service/CommentService.java
@@ -10,26 +10,38 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.jk.board.dto.CommentRequest;
 import com.jk.board.dto.CommentResponse;
+import com.jk.board.entity.Board;
 import com.jk.board.entity.Comment;
+import com.jk.board.repository.BoardRepository;
 import com.jk.board.repository.CommentRepository;
 
 @Service
 public class CommentService {
 
 	private final CommentRepository commentRepository;
+	private final BoardRepository boardRepository;
 
-	public CommentService(final CommentRepository commentRepository) {
+	public CommentService(final CommentRepository commentRepository, final BoardRepository boardRepository) {
 		this.commentRepository = commentRepository;
+		this.boardRepository = boardRepository;
 	}
 	
 	/*
 	 * 댓글 생성
 	 */
 	@Transactional
-	public Long writeComment(final CommentRequest commentRequest) {
-		Comment comment = commentRepository.save(commentRequest.toEntity());
+	public Long writeComment(final Long boardId, final CommentRequest commentRequest) {
+		Optional<Board> boardOptional = boardRepository.findById(boardId);
 		
-		return comment.getId();
+		if (boardOptional.isPresent()) {
+			Comment comment = commentRequest.toEntity();
+			comment.setBoard(boardOptional.get());
+			Comment savedComment = commentRepository.save(comment);
+			
+			return savedComment.getId();
+		} else {
+			return 0L;
+		}
 	}
 	
 	/*


### PR DESCRIPTION
## Controller 추가 사항
 - ResponseEntity를 이용해 Http 상태코드를 전달하는 writeComment 메서드를 추가했습니다.
- 관련 이슈: #119 Board Entity

## 기타 변경 사항
 ### Board Entity
   - 게시글과 댓글이 양방향일 필요가 없을 것 같아서 양방향 관계에서 단방향 관계로 바꿨습니다.
   - 추후 양방향 관계가 필요하다면 바꾸겠습니다. 
 ### Comment Entity
   - Comment가 Oracle 환경에서 예약어이기 때문에 어노테이션을 통해 이름을 COMMENTS로 변경해주었습니다.
   - 자바 환경 내에서는 Comment로 유지됩니다.
   - Board 필드에도 not null 기능을 어노테이션으로 추가해줬습니다.
   - 연관관계를 설정해주는 setBoard 메서드를 추가했습니다.
 ### Comment Service
   - Board와 연관관계를 설정해주기 위해서  writeComment 메서드에 boardId 매개변수를 추가했습니다.
   - Board Service와는 다른 일은 한다고 생각돼서 Board Repository를 DI 받았습니다.