### PR TITLE
버그 수정: JSON 키 이름이 강제로 변환되는 버그 수정

### DIFF
--- a/board/src/main/java/com/jk/board/dto/BoardRequest.java
+++ b/board/src/main/java/com/jk/board/dto/BoardRequest.java
@@ -13,7 +13,7 @@ public class BoardRequest {
 	private String title;
 	private String content;
 	private String writer;
-	private boolean isDeleted;
+	private Boolean isDeleted;
 	
 	public Board toEntity() {
 		return Board.builder()

--- a/board/src/main/java/com/jk/board/dto/BoardResponse.java
+++ b/board/src/main/java/com/jk/board/dto/BoardResponse.java
@@ -17,7 +17,7 @@ public class BoardResponse {
     private String content;
     private String writer;
     private int hits;
-    private boolean isDeleted;
+    private Boolean isDeleted;
     private LocalDateTime createdDate;
     private LocalDateTime modifiedDate;
     
@@ -27,7 +27,7 @@ public class BoardResponse {
         this.content = board.getContent();
         this.writer = board.getWriter();
         this.hits = board.getHits();
-        this.isDeleted = board.isDeleted();
+        this.isDeleted = board.getIsDeleted();
         this.createdDate = board.getCreatedDate();
         this.modifiedDate = board.getModifiedDate();
     }

--- a/board/src/main/java/com/jk/board/dto/CommentRequest.java
+++ b/board/src/main/java/com/jk/board/dto/CommentRequest.java
@@ -13,7 +13,7 @@ public class CommentRequest {
 
 	private String comment;
 	private String writer;
-	private boolean isDeleted;
+	private Boolean isDeleted;
 	private Board board;
 	
 	public Comment toEntity() {

--- a/board/src/main/java/com/jk/board/dto/CommentResponse.java
+++ b/board/src/main/java/com/jk/board/dto/CommentResponse.java
@@ -16,7 +16,7 @@ public class CommentResponse {
 	private Long id;
 	private String comment;
 	private String writer;
-	private boolean isDeleted;
+	private Boolean isDeleted;
 	private LocalDateTime createdDate;
 	private LocalDateTime modifiedDate;
 	private Board board;
@@ -25,7 +25,7 @@ public class CommentResponse {
 		this.id = comment.getId();
 		this.comment = comment.getComment();
 		this.writer = comment.getWriter();
-		this.isDeleted = comment.isDeleted();
+		this.isDeleted = comment.getIsDeleted();
 		this.createdDate = comment.getCreatedDate();
 		this.modifiedDate = comment.getModifiedDate();
 		this.board = comment.getBoard();

--- a/board/src/main/java/com/jk/board/entity/Board.java
+++ b/board/src/main/java/com/jk/board/entity/Board.java
@@ -50,11 +50,10 @@ public class Board {
 	@Column(nullable = false)
 	private String writer;
 	
-	@Column(nullable = false)
 	private int hits;
 	
 	@Column(nullable = false)
-	private boolean isDeleted;
+	private Boolean isDeleted;
 	
 	@Column(nullable = false)
 	private LocalDateTime createdDate = LocalDateTime.now();

--- a/board/src/main/java/com/jk/board/entity/Comment.java
+++ b/board/src/main/java/com/jk/board/entity/Comment.java
@@ -40,7 +40,7 @@ public class Comment {
 	private String writer;
 	
 	@Column(nullable = false)
-	private boolean isDeleted;
+	private Boolean isDeleted;
 	
 	@Column(nullable = false)
 	private LocalDateTime createdDate = LocalDateTime.now();

--- a/board/src/main/java/com/jk/board/repository/BoardRepository.java
+++ b/board/src/main/java/com/jk/board/repository/BoardRepository.java
@@ -1,16 +1,9 @@
 package com.jk.board.repository;
 
-import java.util.List;
-
-import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.jk.board.entity.Board;
 
 public interface BoardRepository extends JpaRepository<Board, Long> {
-	
-	/*
-	 * 게시글 리스트 조회 (삭제되지 않은)
-	 */
-	List<Board> findAllByIsDeleted(final boolean isDeleted, final Sort sort);
+
 }


### PR DESCRIPTION
## 버그 수정 사항
 ### Board Entity와 DTO
  - 원시 타입인 boolean을 유지하면서 getIsDeleted getter를 만들어서 API를 테스트 했을 때 성공적으로 들어갔습니다.
  - 래퍼 클래스인 Boolean 타입으로 변경했을 때 lombok의 `@Getter` 어노테이션은 isDeleted가 아닌 getIsDeleted를 만들어 주기 때문에 이 방법 또한 성공했습니다.
 ### Comment Entity와 DTO
  - 원시 타입인 boolean을 유지하면서 진행했을 때 Board의 경우와는 다르게 isDeleted가 JSON에서 제대로 나오지 않았습니다.
  - getIsDeleted를 확실하게 만들었음에도 불구하고 deleted로 JSON에서 보내줬습니다.
  - 래퍼 클래스인 Boolean으로 적용했을 때는 정상적으로 isDeleted가 나왔기 때문에 이 방법을 통해 진행했습니다.
 ### 결론
  - 통일성을 위해 래퍼 클래스인 Boolean을 통한 방법으로 진행하기로 결정했습니다. 
 ### 관련 이슈
  - #121 
## 기타 수정 사항
 ### Board Entity
  - 원시 타입은 기본적으로 nullable false로 설정되기 때문에 hits 필드의 `@Column` 어노테이션을 제거했습니다.
 ### Board Repository
  - 더 이상 사용하지 않는 findAllByIsDeleted 메서드를 제거했습니다.