### PR TITLE
버그 수정: jdbc.resultsettable에서 LocalDateTime 자료형이 보이지 않는 버그 수정

### DIFF
--- a/board/build.gradle
+++ b/board/build.gradle
@@ -27,6 +27,7 @@ dependencies {
 	implementation 'nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect' 
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.bgee.log4jdbc-log4j2:log4jdbc-log4j2-jdbc4.1:1.16'
+	implementation 'org.mybatis:mybatis-typehandlers-jsr310:1.0.2'
 	implementation group: 'com.oracle.database.jdbc', name: 'ojdbc11', version: '21.3.0.0'
 	implementation("org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.2")
 	compileOnly 'org.projectlombok:lombok'


### PR DESCRIPTION
## 버그 수정 사항
 - build.gradle에 implementation 'org.mybatis:mybatis-typehandlers-jsr310:1.0.2' 종속성을 추가해서 unread가 아닌 LocalDateTime 자료형이 제대로 나오게 했습니다.
 - 관련 이슈: #94