### PR TITLE
기능 추가: 댓글 리스트 기능 추가

### DIFF
--- a/board/src/main/java/com/jk/board/controller/CommentApiController.java
+++ b/board/src/main/java/com/jk/board/controller/CommentApiController.java
@@ -1,8 +1,10 @@
 package com.jk.board.controller;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -36,5 +38,13 @@ public class CommentApiController {
 		} else {
 			return ResponseEntity.notFound().build();
 		}
+	}
+	
+	/*
+	 * 댓글 리스트 조회
+	 */
+	@GetMapping("/boards/{boardId}/comments")
+	public List<CommentResponse> findAllComments(@PathVariable final Long boardId) {
+		return commentService.findAllComments(boardId);
 	}
 }

--- a/board/src/main/java/com/jk/board/repository/CommentRepository.java
+++ b/board/src/main/java/com/jk/board/repository/CommentRepository.java
@@ -1,9 +1,14 @@
 package com.jk.board.repository;
 
+import java.util.List;
+
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import com.jk.board.entity.Board;
 import com.jk.board.entity.Comment;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
+	public List<Comment> findAllByBoard(Board board, Sort sort);
 }

--- a/board/src/main/java/com/jk/board/service/CommentService.java
+++ b/board/src/main/java/com/jk/board/service/CommentService.java
@@ -1,5 +1,6 @@
 package com.jk.board.service;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -83,11 +84,17 @@ public class CommentService {
 	/*
 	 * 게시글 리스트 조회
 	 */
-	public List<CommentResponse> findAllBoards() {
-		Sort sort = Sort.by(Direction.DESC, "id", "createdDate");
-		List<Comment> list = commentRepository.findAll(sort);
+	public List<CommentResponse> findAllComments(final Long boardId) {
+		Optional<Board> boardOptional = boardRepository.findById(boardId);
 		
-		return list.stream().map(CommentResponse::new).toList();
+		if (boardOptional.isPresent()) {
+			Sort sort = Sort.by(Direction.DESC, "id", "createdDate");
+			List<Comment> list = commentRepository.findAllByBoard(boardOptional.get(), sort);
+			
+			return list.stream().map(CommentResponse::new).toList();
+		} else {
+			return Collections.emptyList();
+		}
 	}
 	
 	/*


### PR DESCRIPTION
## 기능 추가 사항
 ### Comment Repository
  - 전체 댓글을 가져오는 것이 아닌 게시글 상세 페이지에 해당하는 Id를 가진 댓글을 가져와야 하므로 findAllByBoard(Board board, Sort sort) 메서드를 추가했습니다.
 ### Comment Service
  - findAllBoards로 적혀 있던 메서드를 findAllComments로 의미에 맞게 변경했습니다.
  - 게시글의 id가 필요하기 때문에 매개변수를 추가해줬고 그 id를 바탕으로 Board를 조회 후 댓글을 찾는 로직을 적용해주었습니다.
 ### Comment API Controller
  - Service의 findAllComments 메서드를 사용하는 findAllComments 메서드를 추가했습니다.
  - ResponseEntity를 사용하지 않은 이유는 추후 CustomException을 통해 예외를 처리할 예정이기 때문입니다.
 ### 관련 이슈
  - #134
  
## 테스트 환경
 - Postman을 통해 API 테스트를 진행하였습니다.