### PR TITLE
기능 추가: 게시글 상세 페이지에서 댓글 리스트 보기 기능 추가

### DIFF
--- a/board/src/main/resources/static/css/style.css
+++ b/board/src/main/resources/static/css/style.css
@@ -1309,6 +1309,8 @@ Version 1.0
   border-radius: 2px;
   -webkit-border-radius: 2px;
   -moz-border-radius: 2px;
+  word-wrap: break-word;
+  background-color:rgba(192, 192, 192, 0.15);
 }
 .form-control.input-sm {
   padding: 0 10px;
@@ -1470,6 +1472,8 @@ textarea.form-control {
 	-moz-appearance: none;
 	appearance: none;
 }
+
+
 /*
  * end of file css
  */

--- a/board/src/main/resources/templates/board/view.html
+++ b/board/src/main/resources/templates/board/view.html
@@ -5,6 +5,8 @@
       layout:decorate="~{layout}">
 
     <th:block layout:fragment="content">
+	
+	<!-- Board 영역 -->
     <div class="card-content">
         <form class="form-horizontal form-view">
     		<div class="form-group">
@@ -33,32 +35,40 @@
     		</div>
 		</form>
 
+		<!-- Board 관련 버튼 영역 -->
     	<div class="btn_wrap text-right col-sm-11" style="margin-bottom: 25px;">
     		<a href="javascript: void(0);" onclick="goListWithHref();" class="btn btn-default waves-effect waves-light">뒤로가기</a>
-    		<a href="javascript: void(0);" onclick="goWrite();" class="btn btn-primary waves-effect waves-light">수정하기</a>
+    		<a href="javascript: void(0);" onclick="goWrite();" class="btn btn-violet waves-effect waves-light">수정하기</a>
     		<button type="button" onclick="deleteBoard();" class="btn btn-danger waves-effect waves-light">삭제하기</button>
     	</div>
     	
+    	<!-- Comment 작성 영역 -->
 		<div class="comments">
 			<form id="commentForm" class="form-horizontal form-view">
 				<div class="form-group">
 					<label for="commentWriter" class="col-sm-2 control-label">작성자</label>
 					<div class="col-sm-2">
-						<input type="text" class="form-control" id="commentWriter" placeholder="작성자 이름">
+						<input type="text" class="form-control" id="commentWriter" placeholder="작성자 이름" style="background-color: transparent;">
 					</div>
 				</div>
 				
 				<div class="form-group">
 					<label for="commentText" class="col-sm-2 control-label">댓글</label>
 					<div class="col-sm-9">
-						<textarea class="form-control" id="commentText" rows="3" placeholder="댓글 내용"></textarea>
+						<textarea class="form-control" id="commentText" rows="3" placeholder="댓글 내용" style="background-color: transparent;"></textarea>
 					</div>
 				</div>
 				
+				<!-- Comment 관련 버튼 영역 -->
 				<div class="btn_wrap text-right col-sm-11">
 					<button type="button" onclick="writeComment();" class="btn btn-primary waves-effect waves-light">작성하기</button>
 				</div>
 			</form>
+		</div>
+		
+		<!-- 댓글 리스트 목록 -->
+		<div class="comment-list text-center col-sm-12">
+		
 		</div>
 		
     </div>
@@ -70,12 +80,13 @@
 	
 		window.onload = () => {
 			findBoard();
+			findAllComments();
 		}
 		/*
 		* 게시글 조회
 		*/
 		function findBoard() {
-			const id = /*[[ ${id} ]]*/ 0;
+			const id = /*[[ ${id} ]]*/  0;
 			
 			fetch(`/api/boards/${id}`).then(response => {
 				if(!response.ok) {
@@ -168,6 +179,7 @@
 			
 			return true;
 		}
+		
 		/*
 		* 댓글 등록
 		*/
@@ -200,6 +212,67 @@
 				alert('댓글이 작성되었습니다.');
 			}).catch(error => {
 				alert('댓글 작성에서 오류가 발생하였습니다.');
+			});
+		}
+		
+		/*
+		* 게시글 리스트 조회
+		*/
+		function findAllComments() {
+			const id = /*[[ ${id} ]]*/ 0;
+			const url = `/api/boards/${id}/comments`;
+			
+			fetch(url).then(response => {
+				if (!response.ok) {
+					throw new Error('댓글을 찾을 수 없습니다.');
+				}
+				
+				return response.json();
+			}).then(json => {
+				if (json.length == 0) {
+					document.querySelector('.comment-list').innerHTML = '<p style="margin-bottom: 20px; margin-top: 20px;">등록된 댓글이 없습니다.</p>';
+
+				} else {
+					let commentHtml = '<div class="text-center" style="margin-bottom: 50px; margin-top: 20px;"><h3>댓글 목록</h3></div>';
+					
+					json.forEach(obj => {
+						commentHtml += `
+							<div>
+								<form class="form-horizontal form-view">
+									<div class="form-group">
+										<label for="commentWriter" class="col-sm-2 control-label">작성자</label>
+										<div class="col-sm-2">
+											<span class="form-control">${obj.writer}</span>
+										</div>
+
+										<label for="commentText" class="col-sm-1 control-label">작성일</label>
+										<div class="col-sm-2">
+											<span class="form-control">${obj.modifiedDate ? moment(obj.modifiedDate).format('YYYY-MM-DD HH:mm:ss') : moment(obj.createdDate).format('YYYY-MM-DD HH:mm:ss')}</span>
+										</div>
+									</div>
+									
+									<div class="form-group">
+										<label for="commentWriter" class="col-sm-2 control-label">댓글</label>
+										<div class="col-sm-9">
+											<span class="form-control" style="background-color: rgba(192, 192, 192, 0.15);">${obj.comment}</span>
+										</div>
+									</div>
+									
+									<!-- Comment 관련 버튼 영역 -->
+									<div class="btn_wrap text-right col-sm-11">
+										<button type="button" class="btn btn-violet waves-effect waves-light">수정하기</button>
+										<button type="button" class="btn btn-danger waves-effect waves-light">삭제하기</button>
+									</div>
+								</form>
+							</div>
+
+						`;
+					});
+	
+					document.querySelector('.comment-list').innerHTML = commentHtml;
+				}
+			}).catch(error => {
+				alert('댓글을 찾을 수 없습니다.');
 			});
 		}
 		

--- a/board/src/main/resources/templates/board/write.html
+++ b/board/src/main/resources/templates/board/write.html
@@ -3,7 +3,14 @@
       xmlns:th="http://www.thymeleaf.org"
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
       layout:decorate="~{layout}">
-      
+
+<head>
+	<style>
+		.form-control {
+		  background-color: transparent;
+		}
+	</style>
+</head>
 	<th:block layout:fragment="content">
 		<div class="card-content">
 			<form id = "form" class="form-horizontal">


### PR DESCRIPTION
## 기능 추가 사항
 ### view.html
  - 댓글 리스트를 담을 comment-list 클래스를 추가했습니다.
  - 댓글 리스트를 보여주는 findAllComments() 함수를 추가했습니다. onload를 통해 로딩 시 실행됩니다.
  - 댓글이 존재하지 않을 때는 '등록된 댓글이 없습니다.' 라고 보여줍니다.
  - 댓글이 존재할 때는 댓글 목록이라는 글자와 함께 작성자, 작성일, 댓글 내용을 보여줍니다. 
 ### 관련 이슈
  - #138

## 기타 수정 사항
 ### style.css
  - form-class에 글을 쓸 수 없는 곳을 표시하기 위하여 background-color:rgba(192, 192, 192, 0.15); 속성을 추가 해 옅은 회색으로 배경을 채웠습니다.

 ### view.html
  - 댓글을 작성하는 부분에 작성하는 곳임을 명시하기 위하여 form-class에 투명 배경 style을 추가했습니다.
  - html을 담당하는 부분에 주석을 추가해 어떤 영역을 나타내는 지에 대한 가시성을 올려주었습니다.

 ### write.html
  - 글을 작성 또는 수정하는 View 이기 때문에 개별 태그에 style을 추가하는 것이 아닌 style 태그를 통해 form-control을 수정했습니다.