### PR TITLE
기능 추가: 댓글 수정 API 기능 추가

### DIFF
--- a/board/src/main/java/com/jk/board/controller/CommentApiController.java
+++ b/board/src/main/java/com/jk/board/controller/CommentApiController.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -41,10 +42,17 @@ public class CommentApiController {
 	}
 	
 	/*
+	 * 댓글 수정
+	 */
+	@PatchMapping("/boards/{boardId}/comments/{id}")
+	public Long updateComment(@PathVariable final Long id, @RequestBody final CommentRequest commentRequest) {
+		return commentService.updateComment(id, commentRequest);
+	}
+	/*
 	 * 댓글 삭제
 	 */
 	@DeleteMapping("/boards/{boardId}/comments/{id}")
-	public Long deleteComment(@PathVariable final Long boardId, @PathVariable final Long id) {
+	public Long deleteComment(@PathVariable final Long id) {
 		return commentService.deleteComment(id);
 	}
 }

--- a/board/src/main/java/com/jk/board/service/CommentService.java
+++ b/board/src/main/java/com/jk/board/service/CommentService.java
@@ -47,18 +47,10 @@ public class CommentService {
 	 */
 	@Transactional
 	public Long updateComment(final Long id, final CommentRequest commentRequest) {
-		Optional<Comment> commentOptional = commentRepository.findById(id);
+		Comment comment = commentRepository.findById(id).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
+		comment.update(commentRequest.getComment(), commentRequest.getWriter());
 		
-		if (commentOptional.isPresent()) {
-			Comment comment = commentOptional.get();
-			comment.update(commentRequest.getComment(), commentRequest.getWriter());
-			
-			return id;
-		} else {
-			// Oracle 시퀀스 기반으로 작동하기 때문에 절대 0 이하로 값이 나올 수 없다.
-			// 댓글은 게시글의 부가기능이기 때문에 댓글에서 예외를 날려서 게시글이 로드가 되지 않으면 안된다.
-			return 0L;
-		}
+		return id;
 	}
 	
 	/*


### PR DESCRIPTION
## 기능 추가 사항
 ### Comment Service
  - updateComment 메서드를 Optional이 아닌 orElseThrow()를 이용해 처리했습니다. 
 ### Comment API Controller
  - @PatchMapping을 이용해 updateComment 메서드를 생성했습니다.
  - deleteComment 메서드의 boardId 매개변수를 제거했습니다.
 ### 관련 이슈
 - #148 

## 테스트 환경
 - **Postman**