### PR TITLE
기능 추가: 댓글 상세 정보 조회 API 기능 추가

### DIFF
--- a/board/src/main/java/com/jk/board/controller/CommentApiController.java
+++ b/board/src/main/java/com/jk/board/controller/CommentApiController.java
@@ -48,11 +48,20 @@ public class CommentApiController {
 	public Long updateComment(@PathVariable final Long id, @RequestBody final CommentRequest commentRequest) {
 		return commentService.updateComment(id, commentRequest);
 	}
+	
 	/*
 	 * 댓글 삭제
 	 */
 	@DeleteMapping("/boards/{boardId}/comments/{id}")
 	public Long deleteComment(@PathVariable final Long id) {
 		return commentService.deleteComment(id);
+	}
+	
+	/*
+	 * 댓글 상세 정보 조회
+	 */
+	@GetMapping("/boards/{boardId}/comments/{id}")
+	public CommentResponse findCommentById(@PathVariable final Long id) {
+		return commentService.findCommentById(id);
 	}
 }

--- a/board/src/main/java/com/jk/board/service/CommentService.java
+++ b/board/src/main/java/com/jk/board/service/CommentService.java
@@ -1,7 +1,6 @@
 package com.jk.board.service;
 
 import java.util.List;
-import java.util.Optional;
 
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
@@ -61,7 +60,7 @@ public class CommentService {
 		Comment comment = commentRepository.findById(id).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
 		comment.delete();
 		
-		return comment.getId();
+		return id;
 	}
 	
 	/*
@@ -80,7 +79,9 @@ public class CommentService {
 	 * 댓글 상세정보 조회
 	 */
 	@Transactional
-	public Optional<CommentResponse> findCommentById(final Long id) {
-		return commentRepository.findById(id).map(CommentResponse::new);
+	public CommentResponse findCommentById(final Long id) {
+		Comment comment = commentRepository.findById(id).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
+		
+		return new CommentResponse(comment); 
 	}
 }


### PR DESCRIPTION
## 기능 추가 사항
### Comment Service
  - findCommentById 메서드를 Optional을 반환하는 게 아닌 orElseThrow를 통해 직접 값을 반환 받게 합니다.
 ### Comment API Controller
  - 댓글 상세 정보를 조회하는 메서드인 findCommentById를 추가했습니다. 
### 관련 이슈
  - #153

## 기타 수정 사항
 ### Comment Service
  - deleteComment 메서드의 반환 값을 어차피 같은 값이기 때문에 매개변수 id를 반환하게 했습니다.

## 테스트 환경
 - **Postman을 활용한 API 테스트**