### PR TITLE
기능 추가: View와 댓글 페이지네이션 연동 기능 추가

### DIFF
--- a/board/src/main/java/com/jk/board/controller/CommentApiController.java
+++ b/board/src/main/java/com/jk/board/controller/CommentApiController.java
@@ -1,7 +1,5 @@
 package com.jk.board.controller;
 
-import java.util.List;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -40,11 +38,6 @@ public class CommentApiController {
 	/*
 	 * 댓글 리스트 조회
 	 */
-//	@GetMapping("/boards/{boardId}/comments")
-//	public List<CommentResponse> findAllComments(@PathVariable final Long boardId) {
-//		return commentService.findAllComments(boardId);
-//	}
-	
 	@GetMapping("/boards/{boardId}/comments")
 	public Page<CommentResponse> findAllComments(@PathVariable final Long boardId,
 												 @PageableDefault(page = 0, size = 5, sort="id", direction=Sort.Direction.DESC) final Pageable pageable) {

--- a/board/src/main/java/com/jk/board/repository/CommentRepository.java
+++ b/board/src/main/java/com/jk/board/repository/CommentRepository.java
@@ -14,5 +14,5 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
 	public List<Comment> findAllByBoardAndIsDeleted(Board board, boolean isDeleted, Sort sort);
 	
-	public Page<Comment> findAllByBoard(Board board, Pageable pageable);
+	public Page<Comment> findAllByBoardAndIsDeleted(Board board, boolean isDeleted, Pageable pageable);
 }

--- a/board/src/main/java/com/jk/board/service/CommentService.java
+++ b/board/src/main/java/com/jk/board/service/CommentService.java
@@ -83,7 +83,7 @@ public class CommentService {
 	public Page<CommentResponse> findAllComments(final Long boardId, final Pageable pageable) {
 		Board board = boardRepository.findById(boardId).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
 		
-		return commentRepository.findAllByBoard(board, pageable).map(CommentResponse::new);
+		return commentRepository.findAllByBoardAndIsDeleted(board, false, pageable).map(CommentResponse::new);
 	}
 	
 	/*

--- a/board/src/main/resources/templates/board/view.html
+++ b/board/src/main/resources/templates/board/view.html
@@ -71,6 +71,12 @@
 		
 		</div>
 		
+		<!-- 댓글 Pagination 영역-->
+		<nav aria-label="Page navigation" class="text-center">
+			<ul class="pagination">
+				
+			</ul>
+		</nav>		
     </div>
     </th:block>
 
@@ -221,9 +227,12 @@
 		/*
 		* 게시글 리스트 조회
 		*/
-		function findAllComments() {
+		function findAllComments(pageNumber) {
 			const id = /*[[ ${id} ]]*/ 0;
-			const url = `/api/boards/${id}/comments`;
+			const pageNumberParam = Number(new URLSearchParams(location.search).get('page'));
+			pageNumber = (pageNumber) ? pageNumber : ((pageNumberParam) ? pageNumberParam : 0); 
+			console.log(pageNumber);
+			const url = `/api/boards/${id}/comments?page=${pageNumber}`;
 			
 			fetch(url).then(response => {
 				if (!response.ok) {
@@ -233,15 +242,18 @@
 				return response.json();
 			}).then(page => {
 				
-				json = page.content;
+				comment = page.content;
 				
-				if (json.length == 0) {
+				if (comment.length == 0) {
 					document.querySelector('.comment-list').innerHTML = '<p style="margin-bottom: 20px; margin-top: 20px;">등록된 댓글이 없습니다.</p>';
 
 				} else {
-					createCommentList(json);
+					createCommentList(comment);
 				}
+				
+				renderPageButtons(page);
 			}).catch(error => {
+				console.log(error);
 				alert('댓글을 찾을 수 없습니다.');
 			});
 		}
@@ -312,7 +324,52 @@
 				alert('댓글 삭제 중 오류가 발생했습니다.')
 			});
 		}
-		
+
+		/*
+		* 페이지 HTML 렌더링
+		*/
+		function renderPageButtons(page) {
+			let html = '';
+			const offset = page.pageable.offset;
+			const pageNumber = page.pageable.pageNumber;
+			const pageSize = page.pageable.pageSize;
+			const totalElements = page.totalElements;
+			
+			// 0부터 시작하기 때문에 개수를 하나 줄여서 계산합니다.
+			const totalPages = page.totalPages - 1;
+			const startPage = Math.floor(pageNumber / pageSize) * pageSize;
+			let endPage = startPage + pageSize - 1;
+			if (endPage > totalPages) {
+				endPage = totalPages;
+			}
+			
+			const existPrevPage = startPage != 0;
+			const existNextPage = ((endPage + 1) * pageSize) < totalElements;
+			
+			// 첫 페이지, 이전 페이지
+			if (existPrevPage) {
+				html += `
+						<li><a href="javascrpit:void(0)" onclick="findAllComments(0)" aria-label="Previous"><span aria-hidden="true">&laquo;</span></a><li>
+						<li><a href="javascript:void(0)" onclick="findAllComments(${startPage-1})" aria-label="Previous"><span aria-hidden="true">&lsaquo;</span></a></li>
+				`;
+			}
+			
+			// 페이지 번호
+			for (let i = startPage; i <= endPage; i++) {
+				const active = (i === pageNumber) ? 'class="active"' : '';
+				html += `<li ${active}><a href="javascrpit:void(0)" onclick="findAllComments(${i})">${i+1}</a></li> `;
+			}
+			// 다음 페이지, 마지막 페이지
+			if (existNextPage) {
+				html += `
+						<li><a href="javascript:void(0)" onclick="findAllComments(${endPage+1})" aria-label="Next"><span aria-hidden="true">&rsaquo;</span></a></li>
+						<li><a href="javascript:void(0)" onclick="findAllComments(${totalPages})" aria-label="Next"><span aria-hidden="true">&raquo;</span></a></li>
+				`;
+			}
+			
+			document.querySelector('.pagination').innerHTML = html;
+		}
+				
 	/*]]>*/
 	</script>
 	</th:block>


### PR DESCRIPTION
## 기능 추가 사항
 ### view.html
  - findAllComments 
     - 현재 페이지에 따른 접근 기능을 추가해줬습니다. 
     - 댓글 리스트를 만들고 난 뒤 댓글 페이지 버튼을 렌더링하는 renderPageButtons 함수를 추가했습니다.
  - renderPageButtons 
     - 게시글 리스트와는 다르게 Spring Data JPA에서 지원하는 Page와 Pageable을 이용해 페이지네이션 기능을 처리했습니다.
 
### 관련 이슈
  - #163

## 테스트 환경
 - **웹 사이트 테스트 환경**

## 기타 추가 사항
 - Pageable을 통한 새로운 조회를 할 때 isDeleted가 없이 댓글을 조회하고 있었으므로 수정해주었습니다.