### PR TITLE
기능 추가: 새로고침 시 댓글 페이지 유지 기능 추가

### DIFF
--- a/board/src/main/resources/templates/board/view.html
+++ b/board/src/main/resources/templates/board/view.html
@@ -329,6 +329,12 @@
 		* 페이지 HTML 렌더링
 		*/
 		function renderPageButtons(page) {
+			
+			if (!page) {
+				document.querySelector('.pagination').innerHTML = '';
+				throw new Error('Missing required parameters...');
+			}
+			
 			let html = '';
 			const offset = page.pageable.offset;
 			const pageNumber = page.pageable.pageNumber;
@@ -368,6 +374,15 @@
 			}
 			
 			document.querySelector('.pagination').innerHTML = html;
+			
+			const urlSearchParams = new URLSearchParams(location.search);
+			urlSearchParams.set('page', pageNumber);
+			
+			const updatedQuery = urlSearchParams.toString();
+			
+			const updatedUrl = location.pathname + '?' + updatedQuery;
+			
+			history.replaceState({}, '', updatedUrl);			
 		}
 				
 	/*]]>*/


### PR DESCRIPTION
## 기능 추가 사항
 - location.search를 통해 Query String을 추출한 뒤 page만 현재 페이지 번호로 수정해줍니다.
 - 그 Query String을 문자열로 변환한 뒤 location.pathname과 합쳐 history.replaceState 히스토리를 변경해줍니다.
 - 이를 통해 댓글 페이지를 새로고침해도 유지할 수 있습니다.
 - 관련 이슈: #168

## 테스트 환경
 - **웹 사이트 테스트**