### PR TITLE
성능 개선: 현재 페이지 버튼 클릭 성능 개선

### DIFF
--- a/board/src/main/resources/templates/board/view.html
+++ b/board/src/main/resources/templates/board/view.html
@@ -230,8 +230,7 @@
 		function findAllComments(pageNumber) {
 			const id = /*[[ ${id} ]]*/ 0;
 			const pageNumberParam = Number(new URLSearchParams(location.search).get('page'));
-			pageNumber = (pageNumber) ? pageNumber : ((pageNumberParam) ? pageNumberParam : 0); 
-			console.log(pageNumber);
+			pageNumber = (pageNumber || pageNumber === 0) ? pageNumber : ((pageNumberParam) ? pageNumberParam : 0); 
 			const url = `/api/boards/${id}/comments?page=${pageNumber}`;
 			
 			fetch(url).then(response => {
@@ -355,15 +354,18 @@
 			// 첫 페이지, 이전 페이지
 			if (existPrevPage) {
 				html += `
-						<li><a href="javascrpit:void(0)" onclick="findAllComments(0)" aria-label="Previous"><span aria-hidden="true">&laquo;</span></a><li>
+						<li><a href="javascript:void(0)" onclick="findAllComments(0)" aria-label="Previous"><span aria-hidden="true">&laquo;</span></a><li>
 						<li><a href="javascript:void(0)" onclick="findAllComments(${startPage-1})" aria-label="Previous"><span aria-hidden="true">&lsaquo;</span></a></li>
 				`;
 			}
 			
 			// 페이지 번호
 			for (let i = startPage; i <= endPage; i++) {
-				const active = (i === pageNumber) ? 'class="active"' : '';
-				html += `<li ${active}><a href="javascrpit:void(0)" onclick="findAllComments(${i})">${i+1}</a></li> `;
+				if (i === pageNumber) {
+					html += `<li class="active"><a href="javascript:void(0)">${i+1}</a></li> `;
+				} else {
+					html += `<li><a href="javascript:void(0)" onclick="findAllComments(${i})">${i+1}</a></li> `;
+				}
 			}
 			// 다음 페이지, 마지막 페이지
 			if (existNextPage) {


### PR DESCRIPTION
## 성능 개선 사항
 - 페이지 HTML 렌더링을 하는 함수인 renderPageButtons 함수에서 페이지 번호를 만드는 for문을 현재 번호일 때는 class="active"를 넣어주고 아닐 때는 onclick을 넣어주는 로직을 추가했습니다.
 - 이로 인해 현재 페이지 버튼에는 onclick 기능이 없어 클릭해도 API를 호출하지 않습니다.
 - 관련 이슈: #169

## 버그 수정 사항
 - JavaScript에서 0은 false 취급 당하기 때문에 findAllComments 함수에서 page를 정하는 삼항연산자에 pageNumber === 0을 OR 연산으로 추가해줬습니다.
 - 그 전에는 pageNumberParam이 존재하지 않아 자동으로 0으로 되기 때문에 문제 없었지만, #170 에서 댓글 페이지를 유지하기 위해 추가 되었으므로 1번째(0) 페이지를 정상적으로 이동할 수 없게 되었었습니다.

## 기타 수정 사항
 - 태그 내의 javascript 오타와 괄호 오타를 제거했습니다.

## 테스트 환경
 - **웹 사이트 테스트**