### PR TITLE
성능개선: 다대일 연관관계 시 FetchType에 따른 성능 개선

### DIFF
--- a/board/src/main/java/com/jk/board/entity/Board.java
+++ b/board/src/main/java/com/jk/board/entity/Board.java
@@ -1,17 +1,12 @@
 package com.jk.board.entity;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.OrderBy;
 import jakarta.persistence.SequenceGenerator;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -62,10 +57,6 @@ public class Board {
 	private LocalDateTime createdDate = LocalDateTime.now();
 	
 	private LocalDateTime modifiedDate;
-	
-//	@OneToMany(mappedBy = "board", fetch = FetchType.EAGER, cascade = CascadeType.REMOVE)
-//	@OrderBy("id ASC")
-//	private List<Comment> comments;
 	
 	@Builder
 	public Board(String title, String content, String writer, int hits, boolean isDeleted) {

--- a/board/src/main/java/com/jk/board/entity/Comment.java
+++ b/board/src/main/java/com/jk/board/entity/Comment.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -50,7 +51,7 @@ public class Comment {
 	
 	private LocalDateTime modifiedDate;
 	
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "BOARD_ID", nullable = false)
 	private Board board;
 

--- a/board/src/main/java/com/jk/board/service/CommentService.java
+++ b/board/src/main/java/com/jk/board/service/CommentService.java
@@ -1,11 +1,7 @@
 package com.jk.board.service;
 
-import java.util.List;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.domain.Sort.Direction;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -67,18 +63,6 @@ public class CommentService {
 	
 	/*
 	 * 댓글 리스트 조회
-	 */
-	public List<CommentResponse> findAllComments(final Long boardId) {
-		Board board = boardRepository.findById(boardId).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
-		Sort sort = Sort.by(Direction.DESC, "id", "createdDate");
-		
-		List<Comment> list = commentRepository.findAllByBoardAndIsDeleted(board, false, sort);
-
-		return list.stream().map(CommentResponse::new).toList();
-	}
-	
-	/*
-	 * 댓글 리스트 조회(Page, Pageable)
 	 */
 	public Page<CommentResponse> findAllComments(final Long boardId, final Pageable pageable) {
 		Board board = boardRepository.findById(boardId).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));

--- a/board/src/main/resources/templates/board/view.html
+++ b/board/src/main/resources/templates/board/view.html
@@ -218,7 +218,7 @@
 				alert('댓글이 작성되었습니다.');
 				commentForm.commentWriter.value = '';
         		commentForm.commentText.value = '';
-				findAllComments();
+				findAllComments(0);
 			}).catch(error => {
 				alert('댓글 작성에서 오류가 발생하였습니다.');
 			});


### PR DESCRIPTION
## 성능 개선 사항
 - Comment Entity의 `@ManyToOne` 어노테이션에 지연 로딩 기능을 추가했습니다. 
   - 기본적으로 `@XXXToOne` 어노테이션들은 즉시 로딩을 합니다.
 - 관련 이슈: #173 

## 테스트 환경
 - **웹 사이트 테스트**

## 기타 수정 사항
 ### Board Entity
  - 양방향 연결이 필요할 경우도 있으니 코드를 만들어 놓고 주석 처리를 진행했는데, 필요가 없어서 제거했습니다. 
 ### Comment Service
  - 기존에 있던 댓글 리스트 조회 함수를 제거했습니다. 
 ### view.html
  - 댓글 작성 시 댓글의 첫 페이지가 아닌 현재 페이지에 남아있어서 수정했습니다.