### PR TITLE
기능 추가: 다중 파일 업로드 기능 추가(파일 Entity 생성)

### DIFF
--- a/board/src/main/java/com/jk/board/entity/File.java
+++ b/board/src/main/java/com/jk/board/entity/File.java
@@ -1,0 +1,61 @@
+package com.jk.board.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.SequenceGenerator;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@SequenceGenerator(
+		name = "BOARD_FILE_ID_SEQ_GENERATOR",
+		sequenceName = "BOARD_FILE_ID_SEQ",
+		initialValue = 1,
+		allocationSize = 1
+		)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity(name = "BOARD_FILE")
+public class File {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "BOARD_FILE_ID_SEQ_GENERATOR")
+	@Column(name = "BOARD_FILE_ID")
+	private Long id;
+	
+	@Column(nullable = false)
+	private String originalName;
+	
+	@Column(nullable = false)
+	private String savedName;
+	
+	@Column(name = "FILE_SIZE")
+	private long size;
+	
+	private boolean isDeleted;
+	
+	public boolean getIsDeleted() {
+		return this.isDeleted;
+	}
+	
+	@Column(nullable = false)
+	private LocalDateTime createdDate = LocalDateTime.now();
+	
+	private LocalDateTime deletedDate;
+	
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "BOARD_ID", nullable = false)
+	private Board board;
+	
+	public void setBoard(Board board) {
+		this.board = board;
+	}
+}


### PR DESCRIPTION
## 기능 추가 사항
 - **name 옵션을 통해 이름을 따로 설정한 이유**
   - FILE과 SIZE는 oracle에서 예약어이므로 이름을 변경해서 DB와 연결해주었습니다.

 - **원본 파일명과 저장 파일명을 따로 두는 이유**
   - OS에 따라 파일이 저장되지 않거나 이름이 자동으로 바뀐 채 업로드되는 이슈가 있기 때문입니다.(윈도우의 경우 파일명 뒤에 숫자가 붙습니다.)
   - 이 이슈를 방지하기 위해 저장 파일명에는 UUID라고 불리는 고유 식별자를 저장해서 파일을 구분합니다.
 
- **파일 수정 시간이 없는 이유**
   - 기존 피일이 업로드된 게시글을 수정한다고 했을 때 파일이 추가/삭제되거나 기존 파일이 다른 파일로 변경되는 경우, 기존에 등록된 모든 파일을 삭제처리한 후 추가/삭제/변경된 파일을 새롭게 생성하는 방식을 이용하기 때문입니다.

- **관련 이슈**
  - #172 