### PR TITLE
기능 추가: 다중 파일 업로드 기능 추가(파일 DTO 생성)

### DIFF
--- a/board/src/main/java/com/jk/board/dto/FileRequest.java
+++ b/board/src/main/java/com/jk/board/dto/FileRequest.java
@@ -1,0 +1,28 @@
+package com.jk.board.dto;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class FileRequest {
+
+	private Long id;
+	private Long boardId;
+	private String originalName;
+	private String savedName;
+	private long size;
+	
+	@Builder
+	public FileRequest(String originalName, String savedName, long size) {
+		this.originalName = originalName;
+		this.savedName = savedName;
+		this.size = size;
+	}
+	
+	public void setBoardId(Long boardId) {
+		this.boardId = boardId;
+	}
+}


### PR DESCRIPTION
## 기능 추가 사항
 - **다른 RequestDTO와 달리 id를 가지고 있는 이유**
   - 댓글은 게시글이 작성된 이후 작성하지만, 첨부 파일은 게시글을 작성하면서 추가되어야 하므로, `@PathVariable` 같은 걸 통해 URL로부터 받아올 수가 없습니다.

 - **ResponseDTO가 없는 이유**
   - 응답을 하는 것이 아닌 클릭을 통해 다운로드를 하는 것이 보통이기 때문에 특별하게 ResponseDTO가 필요하지 않습니다.

 - **관련 이슈**
   - #172 