### PR TITLE
기능추가: 다중 파일 업로드 기능 추가(파일 Repository 생성)

### DIFF
--- a/board/src/main/java/com/jk/board/dto/FileRequest.java
+++ b/board/src/main/java/com/jk/board/dto/FileRequest.java
@@ -1,5 +1,8 @@
 package com.jk.board.dto;
 
+import com.jk.board.entity.Board;
+import com.jk.board.entity.File;
+
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,19 +13,37 @@ import lombok.NoArgsConstructor;
 public class FileRequest {
 
 	private Long id;
-	private Long boardId;
 	private String originalName;
 	private String savedName;
+	private String uploadDir;
+	private String extension;
 	private long size;
+	private String contentType;
+	private Board board;
 	
+	public void setBoard(Board board) {
+		this.board = board;
+	}
+
 	@Builder
-	public FileRequest(String originalName, String savedName, long size) {
+	public FileRequest(String originalName, String savedName, String uploadDir, String extension, long size,
+			String contentType) {
 		this.originalName = originalName;
 		this.savedName = savedName;
+		this.uploadDir = uploadDir;
+		this.extension = extension;
 		this.size = size;
+		this.contentType = contentType;
 	}
 	
-	public void setBoardId(Long boardId) {
-		this.boardId = boardId;
+	public File toEntity() {
+		return File.builder()
+				.originalName(originalName)
+				.savedName(savedName)
+				.uploadDir(uploadDir)
+				.extension(extension)
+				.size(size)
+				.contentType(contentType)
+				.build();
 	}
 }

--- a/board/src/main/java/com/jk/board/entity/File.java
+++ b/board/src/main/java/com/jk/board/entity/File.java
@@ -2,8 +2,12 @@ package com.jk.board.entity;
 
 import java.time.LocalDateTime;
 
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -12,10 +16,12 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.SequenceGenerator;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
+@EntityListeners(AuditingEntityListener.class)
 @SequenceGenerator(
 		name = "BOARD_FILE_ID_SEQ_GENERATOR",
 		sequenceName = "BOARD_FILE_ID_SEQ",
@@ -37,17 +43,24 @@ public class File {
 	@Column(nullable = false)
 	private String savedName;
 	
+	private String uploadDir;
+	
+	private String extension;
+	
 	@Column(name = "FILE_SIZE")
 	private long size;
+
+	private String contentType;
 	
 	private boolean isDeleted;
 	
 	public boolean getIsDeleted() {
 		return this.isDeleted;
 	}
-	
+
+	@CreatedDate
 	@Column(nullable = false)
-	private LocalDateTime createdDate = LocalDateTime.now();
+	private LocalDateTime createdDate;
 	
 	private LocalDateTime deletedDate;
 	
@@ -57,5 +70,17 @@ public class File {
 	
 	public void setBoard(Board board) {
 		this.board = board;
+	}
+
+	@Builder
+	public File(String originalName, String savedName, String uploadDir, String extension, long size,
+			String contentType, boolean isDeleted) {
+		this.originalName = originalName;
+		this.savedName = savedName;
+		this.uploadDir = uploadDir;
+		this.extension = extension;
+		this.size = size;
+		this.contentType = contentType;
+		this.isDeleted = isDeleted;
 	}
 }

--- a/board/src/main/java/com/jk/board/repository/FileRepository.java
+++ b/board/src/main/java/com/jk/board/repository/FileRepository.java
@@ -1,0 +1,9 @@
+package com.jk.board.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.jk.board.entity.File;
+
+public interface FileRepository extends JpaRepository<File, Long> {
+
+}


### PR DESCRIPTION
## 기능 추가 사항
 - DB와 연동할 때 필요한 파일 Repository를 생성했습니다.
 - 관련 이슈: #172 

## 기타 수정 사항
### File Entity
  - 필요해 보이는 필드를 추가했습니다.
  - 기존에는 생성 시간을 수동으로 해줬는데 `@EntityListners` 어노테이션을 추가해 `@CreatedDate` 어노테이션을 생성 시간 필드에 추가해줌으로 자동으로 시간을 측정합니다.
    - 성공적으로 될 시 추후 기타 Entity도 수정할 계획입니다.
  - `@Builder`를 이용한 생성자를 추가했습니다. 
 ### File Request DTO
  - Board ID가 아닌 Board 자체를 받게했습니다.
    - Board 자체를 옮기는 오버헤드가 더 클지 Id를 넘겨 받은 후 다시 Board를 구하는 로직이 더 클지는 확인해봐야겠지만 우선은 Board 자체를 넘기는 게 조금 더 ORM스러울 것 같아서 이렇게 진행하겠습니다.
  - 생성자와 File 자체를 생성해주는 toEntity 메서드를 추가했습니다.