### PR TITLE
기능 추가: 다중 파일 업로드 기능 추가(파일 Service 생성, Board Service 수정)

### DIFF
--- a/board/build.gradle
+++ b/board/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 	implementation 'org.bgee.log4jdbc-log4j2:log4jdbc-log4j2-jdbc4.1:1.16'
 	implementation group: 'com.oracle.database.jdbc', name: 'ojdbc11', version: '21.3.0.0'
 	implementation("org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.2")
+	implementation 'commons-io:commons-io:2.11.0'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/board/src/main/java/com/jk/board/controller/BoardApiController.java
+++ b/board/src/main/java/com/jk/board/controller/BoardApiController.java
@@ -30,7 +30,7 @@ public class BoardApiController {
 	 * 게시글 생성
 	 */
 	@PostMapping("/boards")
-	public Long writeBoard(@RequestBody final BoardRequest boardRequest) {
+	public Long writeBoard(@RequestBody final BoardRequest boardRequest) throws Exception {
 		return boardService.writeBoard(boardRequest);
 	}
 
@@ -38,7 +38,7 @@ public class BoardApiController {
 	 * 게시글 수정
 	 */
 	@PatchMapping("/boards/{id}")
-	public Long updateBoard(@PathVariable final Long id, @RequestBody final BoardRequest boardRequest) {
+	public Long updateBoard(@PathVariable final Long id, @RequestBody final BoardRequest boardRequest) throws Exception {
 		return boardService.updateBoard(id, boardRequest);
 	}
 	

--- a/board/src/main/java/com/jk/board/dto/BoardFileRequest.java
+++ b/board/src/main/java/com/jk/board/dto/BoardFileRequest.java
@@ -1,7 +1,7 @@
 package com.jk.board.dto;
 
 import com.jk.board.entity.Board;
-import com.jk.board.entity.File;
+import com.jk.board.entity.BoardFile;
 
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class FileRequest {
+public class BoardFileRequest {
 
 	private Long id;
 	private String originalName;
@@ -26,7 +26,7 @@ public class FileRequest {
 	}
 
 	@Builder
-	public FileRequest(String originalName, String savedName, String uploadDir, String extension, long size,
+	public BoardFileRequest(String originalName, String savedName, String uploadDir, String extension, long size,
 			String contentType) {
 		this.originalName = originalName;
 		this.savedName = savedName;
@@ -36,8 +36,8 @@ public class FileRequest {
 		this.contentType = contentType;
 	}
 	
-	public File toEntity() {
-		return File.builder()
+	public BoardFile toEntity() {
+		return BoardFile.builder()
 				.originalName(originalName)
 				.savedName(savedName)
 				.uploadDir(uploadDir)

--- a/board/src/main/java/com/jk/board/entity/BoardFile.java
+++ b/board/src/main/java/com/jk/board/entity/BoardFile.java
@@ -29,8 +29,8 @@ import lombok.NoArgsConstructor;
 		allocationSize = 1
 		)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Entity(name = "BOARD_FILE")
-public class File {
+@Entity()
+public class BoardFile {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "BOARD_FILE_ID_SEQ_GENERATOR")
@@ -73,7 +73,7 @@ public class File {
 	}
 
 	@Builder
-	public File(String originalName, String savedName, String uploadDir, String extension, long size,
+	public BoardFile(String originalName, String savedName, String uploadDir, String extension, long size,
 			String contentType, boolean isDeleted) {
 		this.originalName = originalName;
 		this.savedName = savedName;

--- a/board/src/main/java/com/jk/board/repository/BoardFileRepository.java
+++ b/board/src/main/java/com/jk/board/repository/BoardFileRepository.java
@@ -1,0 +1,9 @@
+package com.jk.board.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.jk.board.entity.BoardFile;
+
+public interface BoardFileRepository extends JpaRepository<BoardFile, Long> {
+
+}

--- a/board/src/main/java/com/jk/board/repository/FileRepository.java
+++ b/board/src/main/java/com/jk/board/repository/FileRepository.java
@@ -1,9 +1,0 @@
-package com.jk.board.repository;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-
-import com.jk.board.entity.File;
-
-public interface FileRepository extends JpaRepository<File, Long> {
-
-}

--- a/board/src/main/java/com/jk/board/service/BoardFileService.java
+++ b/board/src/main/java/com/jk/board/service/BoardFileService.java
@@ -1,0 +1,96 @@
+package com.jk.board.service;
+
+import java.io.File;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.apache.commons.io.FileUtils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.jk.board.dto.BoardFileRequest;
+import com.jk.board.dto.BoardRequest;
+import com.jk.board.entity.BoardFile;
+import com.jk.board.exception.CustomException;
+import com.jk.board.exception.ErrorCode;
+import com.jk.board.repository.BoardFileRepository;
+import com.jk.board.repository.BoardRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Service
+public class BoardFileService {
+	
+	@Value("${upload.path}")
+	private String uploadDir;
+
+	private final BoardFileRepository fileRepository;
+	private final BoardRepository boardRepository;
+
+	@Transactional
+	public Map<String, Object> saveFiles(final Long boardId, final BoardRequest boardRequest) throws Exception {
+		List<MultipartFile> multipartFiles = boardRequest.getMultipartFiles();
+		
+		Map<String, Object> result = new HashMap<>();
+		
+		List<Long> fileIds = new ArrayList<>();
+		
+		try {
+			if (multipartFiles != null) {
+				if (multipartFiles.size() > 0 && !multipartFiles.get(0).getOriginalFilename().equals("")) {
+					for (MultipartFile file : multipartFiles) {
+						String originalFileName = file.getOriginalFilename();
+						String extension = originalFileName.substring(originalFileName.lastIndexOf("."));
+						String savedFileName = UUID.randomUUID() + extension;
+						
+						File targetFile = new File(uploadDir + savedFileName);
+						
+						result.put("result", "FAIL");
+						
+						BoardFileRequest boardFileRequest = BoardFileRequest.builder()
+								.originalName(originalFileName)
+								.savedName(savedFileName)
+								.uploadDir(uploadDir)
+								.extension(extension)
+								.size(file.getSize())
+								.contentType(file.getContentType())
+								.build();
+						boardFileRequest.setBoard(boardRepository.findById(boardId).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND)));
+						
+						Long fileId = insertFile(boardFileRequest.toEntity());
+						
+						try {
+							InputStream fileStream = file.getInputStream();
+							FileUtils.copyInputStreamToFile(fileStream, targetFile);
+							fileIds.add(fileId);
+							result.put("fileIdxs", fileIds.toString());
+							result.put("result", "OK");
+						} catch (Exception e) {
+							FileUtils.deleteQuietly(targetFile);
+							e.printStackTrace();
+							result.put("result", "FAIL");
+							break;
+						}
+					}
+				}
+			}
+			
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+		
+		return result;
+	}
+
+	@Transactional
+	private Long insertFile(BoardFile boardFile) {
+		return fileRepository.save(null).getId();
+	}
+}

--- a/board/src/main/java/com/jk/board/service/BoardService.java
+++ b/board/src/main/java/com/jk/board/service/BoardService.java
@@ -18,37 +18,48 @@ import com.jk.board.paging.BoardCommonParams;
 import com.jk.board.paging.Pagination;
 import com.jk.board.repository.BoardRepository;
 
+import lombok.RequiredArgsConstructor;
 
+@RequiredArgsConstructor
 @Service
 public class BoardService {
 
 	private final BoardRepository boardRepository;
 	private final BoardMapper boardMapper;
 	
-	public BoardService(final BoardRepository boardRepository, final BoardMapper boardMapper) {
-		this.boardRepository = boardRepository;
-		this.boardMapper = boardMapper;
-	}
+	private final BoardFileService boardFileService;
 	
 	/*
 	 * 게시글 생성
 	 */
 	@Transactional
-	public Long writeBoard(final BoardRequest boardRequest) {
+	public Long writeBoard(final BoardRequest boardRequest) throws Exception {
 		Board board = boardRepository.save(boardRequest.toEntity());
+		Long id = board.getId();
 		
-		return board.getId();
+		saveFiles(id, boardRequest);
+		
+		return id;
 	}
 	
 	/*
 	 * 게시글 수정
 	 */
 	@Transactional
-	public Long updateBoard(final Long id, final BoardRequest boardRequest) {
+	public Long updateBoard(final Long id, final BoardRequest boardRequest) throws Exception {
 		Board board = boardRepository.findById(id).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
 		board.update(boardRequest.getTitle(), boardRequest.getContent(), boardRequest.getWriter());
 		
+		saveFiles(id, boardRequest);
+		
 		return id;
+	}
+	
+	/*
+	 * 파일 저장
+	 */
+	private void saveFiles(final Long id, final BoardRequest boardRequest) throws Exception {
+		boardFileService.saveFiles(id, boardRequest);
 	}
 	
 	/*

--- a/board/src/main/resources/application.properties
+++ b/board/src/main/resources/application.properties
@@ -8,3 +8,9 @@ spring.jpa.properties.hibernate.format_sql=true
 logging.level.org.hibernate.SQL=DEBUG
 logging.level.org.hibernate.type.descriptor.sql=trace
 spring.jpa.hibernate.ddl-auto=none
+
+
+spring.servlet.multipart.max-file-size=10MB
+spring.servlet.multipart.max-request-size=10MB
+
+upload.path=C:/board/files/


### PR DESCRIPTION
## 기능 추가 사항
 ### 파일 Service 생성
  - 파일을 저장하는 saveFiles 메서드를 생성합니다.
  - Board Service와 Board API Controller에서 saveFiles 메서드를 사용하는 메서드에 throws Exception을 추가했습니다.

### Board Service 수정
  - 게시글을 작성할 때 파일을 저장하는 기능이 없었기 때문에 파일을 저장하는 saveFiles 메서드를 게시글 작성과 수정을 하는 writeBoard, updateBoard에 추가해줬습니다.
    - 작성과 수정에 공통적으로 들어가고 Board Service 클래스 내에서만 사용되기 때문에 따로 private 메서드로 처리했습니다.

 ### 관련 이슈
  - #172

## 기타 수정 사항
 - java.io.File과 이름이 헷갈리고 이미 DB에서는 이름을 BOARD_FILE로 사용하므로 File에서 BoardFile로 이름을 변경했습니다.
 - application.properties에 Multipart 사이즈를 제한과 upload.path를 만들어주는 부분을 추가했습니다.
 - commons-io FileUtils를 사용하기 위해 build.gradle에 추가했습니다.