### PR TITLE
기능추가: 다중 파일 업로드 기능 추가

### DIFF
--- a/board/src/main/java/com/jk/board/controller/BoardApiController.java
+++ b/board/src/main/java/com/jk/board/controller/BoardApiController.java
@@ -1,5 +1,6 @@
 package com.jk.board.controller;
 
+import java.util.List;
 import java.util.Map;
 
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -7,9 +8,11 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.jk.board.dto.BoardRequest;
 import com.jk.board.dto.BoardResponse;
@@ -30,7 +33,19 @@ public class BoardApiController {
 	 * 게시글 생성
 	 */
 	@PostMapping("/boards")
-	public Long writeBoard(@RequestBody final BoardRequest boardRequest) throws Exception {
+	public Long wirteBoard(@RequestParam("title") final String title,
+						   @RequestParam("content") final String content,
+						   @RequestParam("writer") final String writer,
+						   @RequestPart("multipartFiles") final List<MultipartFile> multipartFiles) throws Exception {
+		
+		BoardRequest boardRequest = BoardRequest.builder()
+												.title(title)
+												.content(content)
+												.writer(writer)
+												.isDeleted(false)
+												.multipartFiles(multipartFiles)
+												.build();
+		
 		return boardService.writeBoard(boardRequest);
 	}
 
@@ -38,7 +53,20 @@ public class BoardApiController {
 	 * 게시글 수정
 	 */
 	@PatchMapping("/boards/{id}")
-	public Long updateBoard(@PathVariable final Long id, @RequestBody final BoardRequest boardRequest) throws Exception {
+	public Long updateBoard(@PathVariable final Long id,
+							@RequestParam("title") final String title,
+							@RequestParam("content") final String content,
+							@RequestParam("writer") final String writer,
+							@RequestPart("multipartFiles") final List<MultipartFile> multipartFiles) throws Exception {
+		
+		BoardRequest boardRequest = BoardRequest.builder()
+				.title(title)
+				.content(content)
+				.writer(writer)
+				.isDeleted(false)
+				.multipartFiles(multipartFiles)
+				.build();
+		
 		return boardService.updateBoard(id, boardRequest);
 	}
 	

--- a/board/src/main/java/com/jk/board/dto/BoardFileRequest.java
+++ b/board/src/main/java/com/jk/board/dto/BoardFileRequest.java
@@ -20,20 +20,17 @@ public class BoardFileRequest {
 	private long size;
 	private String contentType;
 	private Board board;
-	
-	public void setBoard(Board board) {
-		this.board = board;
-	}
 
 	@Builder
 	public BoardFileRequest(String originalName, String savedName, String uploadDir, String extension, long size,
-			String contentType) {
+			String contentType, Board board) {
 		this.originalName = originalName;
 		this.savedName = savedName;
 		this.uploadDir = uploadDir;
 		this.extension = extension;
 		this.size = size;
 		this.contentType = contentType;
+		this.board = board;
 	}
 	
 	public BoardFile toEntity() {
@@ -44,6 +41,7 @@ public class BoardFileRequest {
 				.extension(extension)
 				.size(size)
 				.contentType(contentType)
+				.board(board)
 				.build();
 	}
 }

--- a/board/src/main/java/com/jk/board/dto/BoardRequest.java
+++ b/board/src/main/java/com/jk/board/dto/BoardRequest.java
@@ -7,6 +7,7 @@ import org.springframework.web.multipart.MultipartFile;
 import com.jk.board.entity.Board;
 
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -24,6 +25,16 @@ public class BoardRequest {
 	}
 	
 	private List<MultipartFile> multipartFiles;
+	
+	@Builder
+	public BoardRequest(String title, String content, String writer, boolean isDeleted,
+			List<MultipartFile> multipartFiles) {
+		this.title = title;
+		this.content = content;
+		this.writer = writer;
+		this.isDeleted = isDeleted;
+		this.multipartFiles = multipartFiles;
+	}
 	
 	public Board toEntity() {
 		return Board.builder()

--- a/board/src/main/java/com/jk/board/entity/BoardFile.java
+++ b/board/src/main/java/com/jk/board/entity/BoardFile.java
@@ -67,14 +67,10 @@ public class BoardFile {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "BOARD_ID", nullable = false)
 	private Board board;
-	
-	public void setBoard(Board board) {
-		this.board = board;
-	}
 
 	@Builder
 	public BoardFile(String originalName, String savedName, String uploadDir, String extension, long size,
-			String contentType, boolean isDeleted) {
+			String contentType, boolean isDeleted, Board board) {
 		this.originalName = originalName;
 		this.savedName = savedName;
 		this.uploadDir = uploadDir;
@@ -82,5 +78,6 @@ public class BoardFile {
 		this.size = size;
 		this.contentType = contentType;
 		this.isDeleted = isDeleted;
+		this.board = board;
 	}
 }

--- a/board/src/main/java/com/jk/board/service/BoardFileService.java
+++ b/board/src/main/java/com/jk/board/service/BoardFileService.java
@@ -31,7 +31,7 @@ public class BoardFileService {
 	@Value("${upload.path}")
 	private String uploadDir;
 
-	private final BoardFileRepository fileRepository;
+	private final BoardFileRepository boardFileRepository;
 	private final BoardRepository boardRepository;
 
 	@Transactional
@@ -61,8 +61,8 @@ public class BoardFileService {
 								.extension(extension)
 								.size(file.getSize())
 								.contentType(file.getContentType())
+								.board(boardRepository.findById(boardId).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND)))
 								.build();
-						boardFileRequest.setBoard(boardRepository.findById(boardId).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND)));
 						
 						Long fileId = insertFile(boardFileRequest.toEntity());
 						
@@ -91,6 +91,6 @@ public class BoardFileService {
 
 	@Transactional
 	private Long insertFile(BoardFile boardFile) {
-		return fileRepository.save(null).getId();
+		return boardFileRepository.save(boardFile).getId();
 	}
 }

--- a/board/src/main/resources/templates/board/write.html
+++ b/board/src/main/resources/templates/board/write.html
@@ -13,27 +13,34 @@
 </head>
 	<th:block layout:fragment="content">
 		<div class="card-content">
-			<form id = "form" class="form-horizontal">
+			<form id = "form" class="form-horizontal" enctype="multipart/form-data">
 				<div class="form-group">
 					<label for="title" class="col-sm-2 control-label">제목</label>
 					<div class="col-sm-10">
-						<input type="text" id="title" class="form-control" placeholder="제목을 입력해 주세요." />
+						<input type="text" id="title" name="title" class="form-control" placeholder="제목을 입력해 주세요." />
 					</div>
 				</div>
 	
 				<div class="form-group">
 					<label for="writer" class="col-sm-2 control-label">이름</label>
 					<div class="col-sm-10">
-						<input type="text" id="writer" class="form-control" placeholder="이름을 입력해 주세요." />
+						<input type="text" id="writer" name="writer" class="form-control" placeholder="이름을 입력해 주세요." />
 					</div>
 				</div>
 	
 				<div class="form-group">
 					<label for="content" class="col-sm-2 control-label">내용</label>
 					<div class="col-sm-10">
-						<textarea id="content" class="form-control" placeholder="내용을 입력해 주세요."></textarea>
+						<textarea id="content" name="content" class="form-control" placeholder="내용을 입력해 주세요."></textarea>
 					</div>
 				</div>
+				
+				<div class="form-group">
+                    <label for="formFileMultiple" class="col-sm-2 control-label">파일업로드</label>
+                    <div class="col-sm-10">
+                    	<input class="form-control" type="file" id="formFileMultiple" name="multipartFiles" multiple>
+                    </div>
+                </div>
 	
 				<div class="btn_wrap text-center">
 					<a href="javascript: void(0);" onclick="goListWithHref();" class="btn btn-default waves-effect waves-light">돌아가기</a>
@@ -128,24 +135,24 @@
 						return false;
 					}
 					
+					/*
 					const form = document.getElementById('form');
 					const params = {
 						title: form.title.value,
 						writer: form.writer.value,
 						content: form.content.value,
-						idDeleted: false
+						// idDleted로 오타가 있었지만 isDeleted가 원시 자료형이였기 때문에 기본 값인 false를 넣어서 오류가 나지 않았던 것 같다.
+						isDeleted: false
 					};
+					*/
+					const formData = new FormData(form);
 					const id = /*[[ ${id} ]]*/ 0;
 					const uri = id ? `/api/boards/${id}` : '/api/boards';
 					const method = id ? 'PATCH' : 'POST';				
 
 					fetch(uri, {
 						method: method,
-						headers: {
-							'Content-Type': 'application/json',
-						},
-						body: JSON.stringify(params)
-
+						body: formData
 					}).then(response => {
 						if (!response.ok) {
 							throw new Error('Request failed...');
@@ -155,6 +162,7 @@
 						goListWithHref();
 
 					}).catch(error => {
+						console.log(error);
 						alert('오류가 발생하였습니다.');
 					});
 				}


### PR DESCRIPTION
## 기능 추가 사항
 ### Board API Controller
  - MultipartFile은 특수한 요청을 하기 때문에 `@RequestBody`로 받을 수가 없습니다.
  - `@RequestParam`과 `@RequestPart`로 받아야하는데 일반 문자열 데이터는 `@RequestParam`으로 MultipartFile은 파일에 더 특화된 `@RequestPart`로 받게 변경했습니다.
    - 게시글 생성이 아닌 수정도 변경하긴 했지만 수정은 다음 커밋에서 처리할 예정입니다.
  - 각각의 매개변수로 받은 뒤 BoardRequest 생성자를 통해 생성해서 Service로 똑같이 보내주게 했습니다.
  
 ### Board Request DTO
  - BoardRequest 객체를 생성하기 위해 BoardRequest에 생성자를 추가했습니다.

 ### write.html
  - 파일을 전달하기 위해서 form 태그에 entype 옵션을 추가했습니다.
  - 다중 파일을 업로드하기 위한 input 태그에 multiple 옵션을 추가했습니다.
  - 기존에 form 값을 가져와 body에 들어갈 값을 만들어 주는 코드에서 각 값에 name을 추가한 후 FormData()를 이용해 값을 자동으로 추가하도록 변경했습니다.
    - isDeleted는 원시 타입이기 때문에 값을 따로 append 해주지 않아도 false이므로 값을 넣는 부분을 생략했습니다.
    - FormData를 통해 값을 보낼 경우 Content-Type을 자동으로 필요한 multipart/form-data를 사용하기 때문에 Content-Type은 생략했습니다.

 ### 관련 이슈
  - #172

## 기타 수정 사항
 ### Board File Entity
  - 객체의 불변성을 위해 Board Setter를 삭제하고 생성자에 추가했습니다.

 ### Board File Request DTO
  - 객체의 불변성을 위해 Board Setter를 삭제하고 생성자에 추가했습니다.
  - Board File Entity 객체를 생성하는 toEntity 메서드에 board를 추가했습니다.

 ### Board File Service
  - Board Setter를 이용하는 부분을 삭제하고 builder를 이용해 처리하도록 바꿨습니다.
  - insertFile 메서드를 사용할 때 null을 넣던 버그를 수정했습니다.
  - 그냥 File에서 BoardFile로 이름을 수정했기 때문에 fileRepository 변수명도 boardFileRepository로 변경했습니다.