### PR TITLE
기능추가: 파일 다운로드 및 수정 기능 추가( Spring Data JPA의 Custom Repository)

### DIFF
--- a/board/src/main/java/com/jk/board/repository/CustomBoardRepository.java
+++ b/board/src/main/java/com/jk/board/repository/CustomBoardRepository.java
@@ -1,0 +1,10 @@
+package com.jk.board.repository;
+
+import java.util.List;
+
+import com.jk.board.dto.BoardFileRequest;
+
+public interface CustomBoardRepository {
+
+	List<BoardFileRequest> selectBoardFileDetail(Long boardId);
+}

--- a/board/src/main/java/com/jk/board/repositoryImpl/CustomBoardRepositoryImpl.java
+++ b/board/src/main/java/com/jk/board/repositoryImpl/CustomBoardRepositoryImpl.java
@@ -1,0 +1,26 @@
+package com.jk.board.repositoryImpl;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.jk.board.dto.BoardFileRequest;
+import com.jk.board.repository.CustomBoardRepository;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+@Repository
+public class CustomBoardRepositoryImpl implements CustomBoardRepository {
+
+	/*
+	 * 게시판 첨부파일 리스트
+	 */
+	@Override
+	public List<BoardFileRequest> selectBoardFileDetail(Long boardId) {
+		
+		return Collections.emptyList();
+	}
+}


### PR DESCRIPTION
## 주요 추가 사항
 - Spring Data JPA에서는 Custom이라는 이름을 붙이고 Impl이라는 postfix를 가진 클래스를 만들면 해당 클래스의 메서드가 자동으로 Spring Data Repository에 추가되는 기능을 제공합니다.
 - CustomXXXRepository 인터페이스를 구현한 CustomXXXRepositoryIpml 클래스의 메서드를 Spring Data JPA가 자동으로 찾아서 등록해줍니다.
 - 즉, JPARepository를 상속하고 있는 인터페이스에 Custom Repository를 추가 상속한다면 그것을 구현한 메서드를 자동으로 사용하면서 Service에 하나의 Repository만 연결해 사용할 수 있습니다.
 - 관련 이슈: #183