### PR TITLE
기능추가: 파일 다운로드 및 수정 기능 추가 (View에서 파일이 보이게 하는 기능)

### DIFF
--- a/board/src/main/java/com/jk/board/controller/BoardViewController.java
+++ b/board/src/main/java/com/jk/board/controller/BoardViewController.java
@@ -7,9 +7,17 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import com.jk.board.repository.CustomBoardRepository;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 @RequestMapping("/board")
 @Controller
 public class BoardViewController {
+	
+	private final CustomBoardRepository customBoardRepository;
 
 	/*
 	 * 게시글 리스트 페이지
@@ -35,6 +43,7 @@ public class BoardViewController {
 	@GetMapping("/view/{id}")
 	public String viewBoard(@PathVariable final Long id, Model model) {
 		model.addAttribute("id", id);
+		model.addAttribute("boardFile", customBoardRepository.selectBoardFileDetail(id));
 		
 		return "board/view";
 	}

--- a/board/src/main/java/com/jk/board/entity/BoardFile.java
+++ b/board/src/main/java/com/jk/board/entity/BoardFile.java
@@ -29,7 +29,7 @@ import lombok.NoArgsConstructor;
 		allocationSize = 1
 		)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Entity()
+@Entity
 public class BoardFile {
 
 	@Id

--- a/board/src/main/java/com/jk/board/repositoryImpl/CustomBoardRepositoryImpl.java
+++ b/board/src/main/java/com/jk/board/repositoryImpl/CustomBoardRepositoryImpl.java
@@ -1,28 +1,53 @@
 package com.jk.board.repositoryImpl;
 
-import java.util.Collections;
 import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
 import com.jk.board.dto.BoardFileRequest;
+import com.jk.board.entity.Board;
+import com.jk.board.exception.CustomException;
+import com.jk.board.exception.ErrorCode;
+import com.jk.board.repository.BoardRepository;
 import com.jk.board.repository.CustomBoardRepository;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
 
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 @Repository
 public class CustomBoardRepositoryImpl implements CustomBoardRepository {
 
 	@PersistenceContext
     private EntityManager entityManager;
 	
+	private final BoardRepository boardRepository;
+	
 	/*
 	 * 게시판 첨부파일 리스트
 	 */
 	@Override
 	public List<BoardFileRequest> selectBoardFileDetail(Long boardId) {
+		Board board = boardRepository.findById(boardId).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
+		String jpql = "SELECT NEW com.jk.board.dto.BoardFileRequest(" +
+					  "boardFile.originalName, " +
+					  "boardFile.savedName, " +
+					  "boardFile.uploadDir, " +
+					  "boardFile.extension, " +
+					  "boardFile.size, " +
+					  "boardFile.contentType, " +
+					  "boardFile.board) " +
+					  "FROM BoardFile boardFile " +
+					  "WHERE boardFile.board = :board " +
+					  "AND boardFile.isDeleted = :isDeleted";
 		
-		return Collections.emptyList();
+		List<BoardFileRequest> result = entityManager.createQuery(jpql, BoardFileRequest.class)
+				.setParameter("board", board)
+				.setParameter("isDeleted", false)
+				.getResultList();
+		
+		return result;
 	}
 }

--- a/board/src/main/resources/templates/board/view.html
+++ b/board/src/main/resources/templates/board/view.html
@@ -33,6 +33,13 @@
     			<label for="inp-type-5" class="col-sm-2 control-label">조회 수</label>
     			<div class="col-sm-9"><p id="hits" class="form-control"></p></div>
     		</div>
+    		
+    		<div class="form-group">
+    			<label for="inp-type-5" class="col-sm-2 control-label">첨부파일</label>
+    			<p th:each="boardFile, index : ${boardFile}">
+              		<a th:href="@{/fileDownload/{id}(boardId=${boardFile.id})}" th:text="${boardFile.originalName}">파일이름1.png</a>
+          		</p>
+    		</div>
 		</form>
 
 		<!-- Board 관련 버튼 영역 -->

--- a/board/src/main/resources/templates/board/write.html
+++ b/board/src/main/resources/templates/board/write.html
@@ -71,6 +71,7 @@
 				function goListWithReplace() {
 					location.replace('/board/list' + location.search);
 				}
+				
 				/*
 				 * 게시글 조회
 				 */
@@ -135,16 +136,6 @@
 						return false;
 					}
 					
-					/*
-					const form = document.getElementById('form');
-					const params = {
-						title: form.title.value,
-						writer: form.writer.value,
-						content: form.content.value,
-						// idDleted로 오타가 있었지만 isDeleted가 원시 자료형이였기 때문에 기본 값인 false를 넣어서 오류가 나지 않았던 것 같다.
-						isDeleted: false
-					};
-					*/
 					const formData = new FormData(form);
 					const id = /*[[ ${id} ]]*/ 0;
 					const uri = id ? `/api/boards/${id}` : '/api/boards';


### PR DESCRIPTION
## 기능 추가 사항
 ### Board View Controller
  - 생성자를 통해 CustomBoardRepositrory를 DI 받는 부분을 추가했습니다.
  - List<BoardFileRequest>를 반환하는 메서드를 model로 보내는 부분을 추가했습니다.
 
 ### CustomBoardRepositoryImpl
  - Board를 가져오기 위해서 BoardRepository를 생성자를 통해 DI 받는 부분을 추가했습니다.
  - JPQL을 통해 BoardFile DTO로 값을 가져오는 기능을 추가했습니다.
    - **파라미터 바인딩을 사용하는 이유**
      - JPQL을 수정해서 직접 문자를 더해 만들어 넣으면 SQL Injection 공격을 당할 수 있습니다.
      - 또한, 파라미터의 값이 달라도 같은 쿼리로 인식해서 JPA는 JPQL을 SQL로 파싱한 결과를 재사용할 수 있습니다. 
      - DB 또한 내부에서 실행한 SQL을 파싱해서 사용하는데 같은 쿼리는 파싱한 결과를 재사용할 수 있습니다. 즉, 성능상 이점이 있습니다.

 ###  view.html
  - Thymeleaf를 통해 반복문으로 첨부 파일 이름을 만들게 했습니다.

## 테스트 환경
 - **웹 사이트 환경**

## 기타 추가 사항
 ### BoardFile Entity
 - `@Entity` 어노테이션에 붙어있는 빈 괄호를 삭제했습니다.

 ### write.html
 - 주석으로 처리된 이전 코드를 삭제했습니다.