### PR TITLE
기능추가: 파일 다운로드 및 수정 기능 추가

### DIFF
--- a/board/src/main/java/com/jk/board/controller/BoardFileController.java
+++ b/board/src/main/java/com/jk/board/controller/BoardFileController.java
@@ -1,0 +1,79 @@
+package com.jk.board.controller;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.file.Path;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.util.FileCopyUtils;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import com.jk.board.entity.BoardFile;
+import com.jk.board.exception.CustomException;
+import com.jk.board.exception.ErrorCode;
+import com.jk.board.repository.BoardFileRepository;
+
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+@Controller
+public class BoardFileController {
+	
+	private final BoardFileRepository boardFileRepository;
+	
+	@GetMapping("/fileDownload/{fileIdx}")
+	@ResponseBody
+	public void downloadFile(HttpServletResponse res, @PathVariable Long fileIdx) throws UnsupportedEncodingException {
+		
+		//파일 조회
+		BoardFile boardFile = boardFileRepository.findById(fileIdx).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
+		
+		//파일 경로
+		Path savedFilePath = Path.of(boardFile.getUploadDir() + File.separator + boardFile.getSavedName());
+		
+		//해당 경로에 파일이 없을 때
+		if (!savedFilePath.toFile().exists()) {
+			throw new RuntimeException("File not found");
+		}
+		
+		//파일 헤더 설정
+		setFileHeader(res, boardFile);
+		
+		//파일 복사
+		copyFile(res, savedFilePath);
+	}
+
+	//파일 헤더 설정
+	private void setFileHeader(HttpServletResponse res, BoardFile boardFile) throws UnsupportedEncodingException {
+		res.setHeader("Content-Disposition", "attachment; filename=\"" + URLEncoder.encode((String) boardFile.getOriginalName(), "UTF-8") + "\";");
+		res.setHeader("Content-Transfer-Encoding", "binary");
+		res.setHeader("Content-Type", "application/download; utf-8");
+		res.setHeader("Pragma", "no-cache;");
+		res.setHeader("Expires", "-1");
+	}
+	
+	//파일 header 설정
+	private void copyFile(HttpServletResponse res, Path savedFilePath) {
+		FileInputStream fis = null;
+		
+		try {
+			fis = new FileInputStream(savedFilePath.toFile());
+			FileCopyUtils.copy(fis, res.getOutputStream());
+			res.getOutputStream().flush();
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		} finally {
+			try {
+				fis.close();
+			} catch (Exception e) {
+				e.printStackTrace();
+			}
+		}
+	}
+}

--- a/board/src/main/java/com/jk/board/dto/BoardFileRequest.java
+++ b/board/src/main/java/com/jk/board/dto/BoardFileRequest.java
@@ -22,8 +22,9 @@ public class BoardFileRequest {
 	private Board board;
 
 	@Builder
-	public BoardFileRequest(String originalName, String savedName, String uploadDir, String extension, long size,
+	public BoardFileRequest(Long id, String originalName, String savedName, String uploadDir, String extension, long size,
 			String contentType, Board board) {
+		this.id = id;
 		this.originalName = originalName;
 		this.savedName = savedName;
 		this.uploadDir = uploadDir;

--- a/board/src/main/java/com/jk/board/repositoryImpl/CustomBoardRepositoryImpl.java
+++ b/board/src/main/java/com/jk/board/repositoryImpl/CustomBoardRepositoryImpl.java
@@ -32,6 +32,7 @@ public class CustomBoardRepositoryImpl implements CustomBoardRepository {
 	public List<BoardFileRequest> selectBoardFileDetail(Long boardId) {
 		Board board = boardRepository.findById(boardId).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
 		String jpql = "SELECT NEW com.jk.board.dto.BoardFileRequest(" +
+					  "boardFile.id, " +
 					  "boardFile.originalName, " +
 					  "boardFile.savedName, " +
 					  "boardFile.uploadDir, " +

--- a/board/src/main/resources/templates/board/view.html
+++ b/board/src/main/resources/templates/board/view.html
@@ -36,14 +36,12 @@
     		
     		<div class="form-group">
 				<label for="inp-type-5" class="col-sm-2 control-label">첨부파일</label>
-				
 				<th:block th:if="${not #lists.isEmpty(boardFile)}">
 	    			<p th:each="boardFile, index : ${boardFile}">
-	              		<a th:href="@{/fileDownload/{id}(boardId=${boardFile.id})}" th:text="${boardFile.originalName}">파일이름1.png</a>
+	              		<a th:href="@{'/fileDownload/' + ${boardFile.id}}" th:text="${boardFile.originalName}">파일이름1.png</a>
 	          		</p>
-          		</th:block>
-          		
-          		<th:block th:else>
+				</th:block>
+          		<th:block th:unless="${not #lists.isEmpty(boardFile)}">
 			        <p class="col-sm-9">첨부파일이 없습니다.</p>
 			    </th:block>
     		</div>


### PR DESCRIPTION
## 기능 추가 사항
 ### BoardFile Controller
  - 파일을 저장하기 위한 BoardFile Controller를 추가했습니다.
    - 캐시와 만료일을 저렇게 정한 이유는 파일 다운로드같은 특이 케이스는 최신 버전의 파일로만 다운돼야하기 때문에 항상 서버에서 데이터를 가져가도록 하기 위해서입니다.

 ### BoardFile Request DTO
  - BoardFile Controller에서  BoardFile의 id에 맞게 GetMapping을 생성했는데 해당 DTO에선 id를 초기화를 하는 부분이 없었습니다.
  - 그러므로, 생성자에 id를 초기화 하는 부분을 추가했습니다.

 ### Custom Board Repository
  - BoardFile의 id를 보내줘야 하므로 쿼리에 boardFile의 id를 보내는 부분을 추가했습니다.

 ### view.html
  - th:href를 통해 보내주는 부분이 잘못 되어있었으므로 수정하였습니다.

 ### 관련 이슈
  - #183

## 테스트 환경
 - **웹 서버 환경**

## 기타 수정 사항
 ### view.html
  - Thymeleaf를 이용한 조건문이 잘못 되어 있었기 때문에 수정했습니다.