### PR TITLE
코드 리팩토링: BoardFileRequest 클래스 명 변경

### DIFF
--- a/board/src/main/java/com/jk/board/dto/BoardFileDTO.java
+++ b/board/src/main/java/com/jk/board/dto/BoardFileDTO.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class BoardFileRequest {
+public class BoardFileDTO {
 
 	private Long id;
 	private String originalName;
@@ -22,7 +22,7 @@ public class BoardFileRequest {
 	private Board board;
 
 	@Builder
-	public BoardFileRequest(Long id, String originalName, String savedName, String uploadDir, String extension, long size,
+	public BoardFileDTO(Long id, String originalName, String savedName, String uploadDir, String extension, long size,
 			String contentType, Board board) {
 		this.id = id;
 		this.originalName = originalName;

--- a/board/src/main/java/com/jk/board/repository/CustomBoardRepository.java
+++ b/board/src/main/java/com/jk/board/repository/CustomBoardRepository.java
@@ -2,9 +2,9 @@ package com.jk.board.repository;
 
 import java.util.List;
 
-import com.jk.board.dto.BoardFileRequest;
+import com.jk.board.dto.BoardFileDTO;
 
 public interface CustomBoardRepository {
 
-	List<BoardFileRequest> selectBoardFileDetail(Long boardId);
+	List<BoardFileDTO> selectBoardFileDetail(Long boardId);
 }

--- a/board/src/main/java/com/jk/board/repositoryImpl/CustomBoardRepositoryImpl.java
+++ b/board/src/main/java/com/jk/board/repositoryImpl/CustomBoardRepositoryImpl.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
-import com.jk.board.dto.BoardFileRequest;
+import com.jk.board.dto.BoardFileDTO;
 import com.jk.board.entity.Board;
 import com.jk.board.exception.CustomException;
 import com.jk.board.exception.ErrorCode;
@@ -29,9 +29,9 @@ public class CustomBoardRepositoryImpl implements CustomBoardRepository {
 	 * 게시판 첨부파일 리스트
 	 */
 	@Override
-	public List<BoardFileRequest> selectBoardFileDetail(Long boardId) {
+	public List<BoardFileDTO> selectBoardFileDetail(Long boardId) {
 		Board board = boardRepository.findById(boardId).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
-		String jpql = "SELECT NEW com.jk.board.dto.BoardFileRequest(" +
+		String jpql = "SELECT NEW com.jk.board.dto.BoardFileDTO(" +
 					  "boardFile.id, " +
 					  "boardFile.originalName, " +
 					  "boardFile.savedName, " +
@@ -44,7 +44,7 @@ public class CustomBoardRepositoryImpl implements CustomBoardRepository {
 					  "WHERE boardFile.board = :board " +
 					  "AND boardFile.isDeleted = :isDeleted";
 		
-		List<BoardFileRequest> result = entityManager.createQuery(jpql, BoardFileRequest.class)
+		List<BoardFileDTO> result = entityManager.createQuery(jpql, BoardFileDTO.class)
 				.setParameter("board", board)
 				.setParameter("isDeleted", false)
 				.getResultList();

--- a/board/src/main/java/com/jk/board/service/BoardFileService.java
+++ b/board/src/main/java/com/jk/board/service/BoardFileService.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import com.jk.board.dto.BoardFileRequest;
+import com.jk.board.dto.BoardFileDTO;
 import com.jk.board.dto.BoardRequest;
 import com.jk.board.entity.BoardFile;
 import com.jk.board.exception.CustomException;
@@ -54,7 +54,7 @@ public class BoardFileService {
 						
 						result.put("result", "FAIL");
 						
-						BoardFileRequest boardFileRequest = BoardFileRequest.builder()
+						BoardFileDTO boardFileDto = BoardFileDTO.builder()
 								.originalName(originalFileName)
 								.savedName(savedFileName)
 								.uploadDir(uploadDir)
@@ -64,7 +64,7 @@ public class BoardFileService {
 								.board(boardRepository.findById(boardId).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND)))
 								.build();
 						
-						Long fileId = insertFile(boardFileRequest.toEntity());
+						Long fileId = insertFile(boardFileDto.toEntity());
 						
 						try {
 							InputStream fileStream = file.getInputStream();

--- a/board/src/main/resources/templates/board/view.html
+++ b/board/src/main/resources/templates/board/view.html
@@ -37,7 +37,7 @@
     		<div class="form-group">
 				<label for="inp-type-5" class="col-sm-2 control-label">첨부파일</label>
 				<th:block th:if="${not #lists.isEmpty(boardFile)}">
-	    			<p th:each="boardFile, index : ${boardFile}">
+	    			<p th:each="boardFile, index : ${boardFile}" class="col-sm-1">
 	              		<a th:href="@{'/fileDownload/' + ${boardFile.id}}" th:text="${boardFile.originalName}">파일이름1.png</a>
 	          		</p>
 				</th:block>
@@ -49,7 +49,7 @@
 
 		<!-- Board 관련 버튼 영역 -->
     	<div class="btn_wrap text-right col-sm-11" style="margin-bottom: 25px;">
-    		<a href="javascript: void(0);" onclick="goListWithHref();" class="btn btn-default waves-effect waves-light">뒤로가기</a>
+    		<a href="javascript: void(0);" onclick="goListWithHref();" class="btn btn-default waves-effect waves-light">목록으로</a>
     		<a href="javascript: void(0);" onclick="goWrite();" class="btn btn-violet waves-effect waves-light">수정하기</a>
     		<button type="button" onclick="deleteBoard();" class="btn btn-danger waves-effect waves-light">삭제하기</button>
     	</div>

--- a/board/src/main/resources/templates/board/write.html
+++ b/board/src/main/resources/templates/board/write.html
@@ -43,7 +43,7 @@
                 </div>
 	
 				<div class="btn_wrap text-center">
-					<a href="javascript: void(0);" onclick="goListWithHref();" class="btn btn-default waves-effect waves-light">돌아가기</a>
+					<a href="javascript: void(0);" onclick="history.back();" class="btn btn-default waves-effect waves-light">돌아가기</a>
 					<button type="button" onclick="writeBoard();" class="btn btn-primary waves-effect waves-light">저장하기</button>
 				</div>
 			</form>


### PR DESCRIPTION
## 코드 리팩토링 사항
 - BoardFileRequest를 사용하고 있던 클래스와 인터페이스를 수정했습니다.
 - 특별히 JPQL을 사용하고 있던 CustomBoardRepositoryImpl 클래스는 따로 변경했습니다.
 - 관련 이슈: #191

## 테스트 환경
 - **웹 사이트 환경**

## 기타 수정 사항
 ### view.html
  - 첨부파일에서 게시글들이 밑으로만 내려가서 UI를 해치기에 `col-sm-1` 클래스를 추가했습니다.
  - 수정을 하다가 취소하고 왔을 수도 있기 때문에 '뒤로가기'라는 표현이 어울리지 않아 '목록으로'라는 표현으로 대체했습니다.

 ### write.html
  - 수정을 하다가 돌아가기라는 건 게시글로 가는 것이지 목록으로 가는 게 아니라고 생각돼서 `history.back()` 함수를 이용해 다시 게시글 상세 페이지로 이동하게 했습니다.