### PR TITLE
기능 추가: 파일 다운로드 및 수정 기능 추가 (수정 화면에서 첨부파일 보이게 하기)

### DIFF
--- a/board/src/main/java/com/jk/board/controller/BoardViewController.java
+++ b/board/src/main/java/com/jk/board/controller/BoardViewController.java
@@ -33,7 +33,9 @@ public class BoardViewController {
 	@GetMapping("/write")
 	public String writeBoard(@RequestParam(required = false) final Long id, Model model) {
 		model.addAttribute("id", id);
-		
+		if (id != null) {
+			model.addAttribute("boardFileOriginalName", customBoardRepository.selectBoardFileOriginalName(id));
+		}
 		return "board/write";
 	}
 	

--- a/board/src/main/java/com/jk/board/dto/BoardFileOriginalName.java
+++ b/board/src/main/java/com/jk/board/dto/BoardFileOriginalName.java
@@ -1,0 +1,20 @@
+package com.jk.board.dto;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BoardFileOriginalName {
+
+	private String originalName;
+
+	@Builder
+	public BoardFileOriginalName(String originalName) {
+		this.originalName = originalName;
+	}
+	
+	
+}

--- a/board/src/main/java/com/jk/board/repository/CustomBoardRepository.java
+++ b/board/src/main/java/com/jk/board/repository/CustomBoardRepository.java
@@ -3,8 +3,13 @@ package com.jk.board.repository;
 import java.util.List;
 
 import com.jk.board.dto.BoardFileDTO;
+import com.jk.board.dto.BoardFileOriginalName;
 
 public interface CustomBoardRepository {
 
 	List<BoardFileDTO> selectBoardFileDetail(Long boardId);
+	
+	//List<String> selectBoardFileOriginalName(Long boardId);
+	
+	List<BoardFileOriginalName> selectBoardFileOriginalName(Long boardId);
 }

--- a/board/src/main/java/com/jk/board/repositoryImpl/CustomBoardRepositoryImpl.java
+++ b/board/src/main/java/com/jk/board/repositoryImpl/CustomBoardRepositoryImpl.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.stereotype.Repository;
 
 import com.jk.board.dto.BoardFileDTO;
+import com.jk.board.dto.BoardFileOriginalName;
 import com.jk.board.entity.Board;
 import com.jk.board.exception.CustomException;
 import com.jk.board.exception.ErrorCode;
@@ -29,7 +30,7 @@ public class CustomBoardRepositoryImpl implements CustomBoardRepository {
 	 * 게시판 첨부파일 리스트
 	 */
 	@Override
-	public List<BoardFileDTO> selectBoardFileDetail(Long boardId) {
+	public List<BoardFileDTO> selectBoardFileDetail(final Long boardId) {
 		Board board = boardRepository.findById(boardId).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
 		String jpql = "SELECT NEW com.jk.board.dto.BoardFileDTO(" +
 					  "boardFile.id, " +
@@ -45,6 +46,25 @@ public class CustomBoardRepositoryImpl implements CustomBoardRepository {
 					  "AND boardFile.isDeleted = :isDeleted";
 		
 		List<BoardFileDTO> result = entityManager.createQuery(jpql, BoardFileDTO.class)
+				.setParameter("board", board)
+				.setParameter("isDeleted", false)
+				.getResultList();
+		
+		return result;
+	}
+	
+	/*
+	 * 게시글 수정 시 첨부파일 이름을 표시하기 위한 리스트
+	 */
+	public List<BoardFileOriginalName> selectBoardFileOriginalName(final Long boardId) {
+		Board board = boardRepository.findById(boardId).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
+		String jpql = "SELECT NEW com.jk.board.dto.BoardFileOriginalName(" +
+					  "bf.originalName) " +
+					  "FROM BoardFile bf " +
+					  "WHERE bf.board = :board " +
+					  "AND bf.isDeleted = :isDeleted";
+		
+		List<BoardFileOriginalName> result = entityManager.createQuery(jpql, BoardFileOriginalName.class)
 				.setParameter("board", board)
 				.setParameter("isDeleted", false)
 				.getResultList();

--- a/board/src/main/resources/templates/board/view.html
+++ b/board/src/main/resources/templates/board/view.html
@@ -37,9 +37,9 @@
     		<div class="form-group">
 				<label for="inp-type-5" class="col-sm-2 control-label">첨부파일</label>
 				<th:block th:if="${not #lists.isEmpty(boardFile)}">
-	    			<p th:each="boardFile, index : ${boardFile}" class="col-sm-1">
-	              		<a th:href="@{'/fileDownload/' + ${boardFile.id}}" th:text="${boardFile.originalName}">파일이름1.png</a>
-	          		</p>
+	    			<span th:each="boardFile : ${boardFile}">
+	              		<a th:href="@{'/fileDownload/' + ${boardFile.id}}" th:text="${boardFile.originalName}" style="margin-right: 20px;">파일이름1.png</a>
+	          		</span>
 				</th:block>
           		<th:block th:unless="${not #lists.isEmpty(boardFile)}">
 			        <p class="col-sm-9">첨부파일이 없습니다.</p>

--- a/board/src/main/resources/templates/board/write.html
+++ b/board/src/main/resources/templates/board/write.html
@@ -34,7 +34,14 @@
 						<textarea id="content" name="content" class="form-control" placeholder="내용을 입력해 주세요."></textarea>
 					</div>
 				</div>
-				
+				<th:block th:if="${not #lists.isEmpty(boardFileOriginalName)}">
+					<div class="form-group">
+						<label for="inp-type-5" class="col-sm-2 control-label">첨부파일</label>
+			    			<span th:each="boardFileOriginalName : ${boardFileOriginalName}" >
+			              		<span th:text="${boardFileOriginalName.originalName}" style="margin-right: 20px;">>파일이름1.png</span>
+			          		</span>
+		    		</div>
+				</th:block>
 				<div class="form-group">
                     <label for="formFileMultiple" class="col-sm-2 control-label">파일업로드</label>
                     <div class="col-sm-10">


### PR DESCRIPTION
## 기능 추가 사항
### BoardFile OriginalName DTO
  - 수정 화면에서는 다운로드 기능이 필요 없으므로 파일 원본 이름만 있으면 되는 상황이었습니다.
  - BoardFile에서 orginalName 필드만 가져와서 보내거나 그냥 BoardFileDTO 클래스를 사용해도 됐지만, 따로 DTO를 만들어 관리하는 게 관리할 게 많아져 힘들 수 있지만 원하는 필드만 있기 때문에 가볍고 책임이 분리될 수 있어 따로 만들었습니다.

### Board View Controller
  - writeBoard 함수에서 작성 및 수정을 진행하고 id 유무에 따라 작성 수정이 달라지는 데 selectBoardFileOriginalName(id) 메서드가 추가됨에 따라 id가 null 이면 오류가 나기 때문에 null 조건식을 추가했습니다.

### Custom Board Repository/Impl
  - 첨부 파일의 원본 이름을 표시하기 위한 리스트를 반환하는 메서드를 추가했습니다.

### wirte.html
  - boardFileOrigianlName이 있을 때만 첨부파일이 보이게 수정했습니다.

 ### 관련 이슈
  - #183

## 테스트 환경
 - **웹 사이트 환경**

## 기타 수정 사항
### view.html
  - index는 반복문에서 필요 없기에 삭제했습니다.
  -  첨부파일에서 `<span>`이 조금 더 보기 좋은 것 같아 수정했습니다.
     - 오른쪽 여백에 침범하는 부분은 추후 수정하겠습니다.
  - col-sm-1 클래스를 지우고 마진을 통해 처리했습니다.
  