### PR TITLE
기능 추가: 파일 다운로드 및 수정 기능 추가 (게시글 수정 시 파일 삭제 기능 추가)

### DIFF
--- a/board/src/main/java/com/jk/board/controller/BoardFileApiController.java
+++ b/board/src/main/java/com/jk/board/controller/BoardFileApiController.java
@@ -1,0 +1,41 @@
+package com.jk.board.controller;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.jk.board.dto.BoardFileOriginalName;
+import com.jk.board.repository.CustomBoardRepository;
+import com.jk.board.service.BoardFileService;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+@RequestMapping("/api")
+@RestController
+public class BoardFileApiController {
+
+	private final BoardFileService boardFileService;
+	
+	private final CustomBoardRepository customBoardRepository;
+	
+	/*
+	 * 파일 원본 이름 리스트 조회
+	 */
+	@GetMapping("/boards/{boardId}/files")
+	public List<BoardFileOriginalName> findAllBoardFileOriginalNames(@PathVariable final Long boardId) {
+		return customBoardRepository.selectBoardFileOriginalName(boardId);
+	}
+	/*
+	 * 파일 삭제
+	 */
+	@DeleteMapping("/boards/{boardId}/files/{id}")
+	public Long deleteBoardFile(@PathVariable final Long id) {
+		return boardFileService.deleteFile(id);
+	}
+}

--- a/board/src/main/java/com/jk/board/dto/BoardFileOriginalName.java
+++ b/board/src/main/java/com/jk/board/dto/BoardFileOriginalName.java
@@ -9,10 +9,12 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class BoardFileOriginalName {
 
+	private Long id;
 	private String originalName;
 
 	@Builder
-	public BoardFileOriginalName(String originalName) {
+	public BoardFileOriginalName(Long id, String originalName) {
+		this.id = id;
 		this.originalName = originalName;
 	}
 	

--- a/board/src/main/java/com/jk/board/entity/BoardFile.java
+++ b/board/src/main/java/com/jk/board/entity/BoardFile.java
@@ -80,4 +80,9 @@ public class BoardFile {
 		this.isDeleted = isDeleted;
 		this.board = board;
 	}
+	
+	public void delete() {
+		this.isDeleted = true;
+		this.deletedDate = LocalDateTime.now();
+	}
 }

--- a/board/src/main/java/com/jk/board/repository/CommentRepository.java
+++ b/board/src/main/java/com/jk/board/repository/CommentRepository.java
@@ -1,10 +1,7 @@
 package com.jk.board.repository;
 
-import java.util.List;
-
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.jk.board.entity.Board;
@@ -12,7 +9,5 @@ import com.jk.board.entity.Comment;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
-	public List<Comment> findAllByBoardAndIsDeleted(Board board, boolean isDeleted, Sort sort);
-	
 	public Page<Comment> findAllByBoardAndIsDeleted(Board board, boolean isDeleted, Pageable pageable);
 }

--- a/board/src/main/java/com/jk/board/repository/CustomBoardRepository.java
+++ b/board/src/main/java/com/jk/board/repository/CustomBoardRepository.java
@@ -8,8 +8,6 @@ import com.jk.board.dto.BoardFileOriginalName;
 public interface CustomBoardRepository {
 
 	List<BoardFileDTO> selectBoardFileDetail(Long boardId);
-	
-	//List<String> selectBoardFileOriginalName(Long boardId);
-	
+
 	List<BoardFileOriginalName> selectBoardFileOriginalName(Long boardId);
 }

--- a/board/src/main/java/com/jk/board/repositoryImpl/CustomBoardRepositoryImpl.java
+++ b/board/src/main/java/com/jk/board/repositoryImpl/CustomBoardRepositoryImpl.java
@@ -59,6 +59,7 @@ public class CustomBoardRepositoryImpl implements CustomBoardRepository {
 	public List<BoardFileOriginalName> selectBoardFileOriginalName(final Long boardId) {
 		Board board = boardRepository.findById(boardId).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
 		String jpql = "SELECT NEW com.jk.board.dto.BoardFileOriginalName(" +
+					  "bf.id, " +
 					  "bf.originalName) " +
 					  "FROM BoardFile bf " +
 					  "WHERE bf.board = :board " +

--- a/board/src/main/java/com/jk/board/service/BoardFileService.java
+++ b/board/src/main/java/com/jk/board/service/BoardFileService.java
@@ -90,7 +90,18 @@ public class BoardFileService {
 	}
 
 	@Transactional
-	private Long insertFile(BoardFile boardFile) {
+	private Long insertFile(final BoardFile boardFile) {
 		return boardFileRepository.save(boardFile).getId();
+	}
+	
+	/*
+	 * 게시판 파일 삭제
+	 */
+	@Transactional
+	public Long deleteFile(final Long boardFileId) {
+		BoardFile boardFile = boardFileRepository.findById(boardFileId).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
+		
+		boardFile.delete();
+		return boardFileId;
 	}
 }

--- a/board/src/main/resources/templates/board/view.html
+++ b/board/src/main/resources/templates/board/view.html
@@ -159,10 +159,7 @@
 			}
 			
 			fetch(`/api/boards/${id}`, {
-				method: 'DELETE',
-				headers: {
-					'Content-Type': 'application/json'
-				}
+				method: 'DELETE'
 			}).then(response => {
 				if (!response.ok) {
 					throw new Error('Request failed...');
@@ -237,7 +234,7 @@
 		}
 		
 		/*
-		* 게시글 리스트 조회
+		* 댓글 리스트 조회
 		*/
 		function findAllComments(pageNumber) {
 			const id = /*[[ ${id} ]]*/ 0;
@@ -319,11 +316,12 @@
 			const id = /*[[ ${id} ]]*/ 0;
 			const url = `/api/boards/${id}/comments/${commentId}`;
 			
+			if (!confirm('해당 댓글을 삭제할까요?') ) {
+				return false;
+			}
+			
 			fetch(url, {
-				method: 'DELETE',
-				headers: {
-					'Content-Type': 'application/json'
-				}
+				method: 'DELETE'
 			}).then(response => {
 				if (!response.ok) {
 					throw new Error('Request failed...');
@@ -332,7 +330,7 @@
 				alert('댓글이 삭제되었습니다.');
 				findAllComments()
 			}).catch(error => {
-				alert('댓글 삭제 중 오류가 발생했습니다.')
+				alert('댓글 삭제 중 오류가 발생했습니다.');
 			});
 		}
 

--- a/board/src/main/resources/templates/board/write.html
+++ b/board/src/main/resources/templates/board/write.html
@@ -35,10 +35,11 @@
 					</div>
 				</div>
 				<th:block th:if="${not #lists.isEmpty(boardFileOriginalName)}">
-					<div class="form-group">
+					<div class="original-name-list form-group">
 						<label for="inp-type-5" class="col-sm-2 control-label">첨부파일</label>
 			    			<span th:each="boardFileOriginalName : ${boardFileOriginalName}" >
-			              		<span th:text="${boardFileOriginalName.originalName}" style="margin-right: 20px;">>파일이름1.png</span>
+			              		<span th:text="${boardFileOriginalName.originalName}" >파일이름1.png</span>
+			              		<button th:attr="onclick='deleteFile(' + ${boardFileOriginalName.id} + ');'" style="margin-right: 20px;">Delete</button>
 			          		</span>
 		    		</div>
 				</th:block>
@@ -163,6 +164,61 @@
 						console.log(error);
 						alert('오류가 발생하였습니다.');
 					});
+				}
+				
+				/*
+				* 파일 삭제하기
+				*/
+				function deleteFile(fileId) {
+					const id = /*[[ ${id} ]]*/ 0;
+					const url = `/api/boards/${id}/files/${fileId}`;
+					
+					if (!confirm('해당 파일을 삭제할까요?')) {
+						return false;
+					}
+					
+					fetch(url, {
+						method: 'DELETE'
+					}).then(response => {
+						if (!response.ok) {
+							throw new Error('Request failed...');
+						}
+						
+						alert('파일이 삭제되었습니다.');
+						location.replace(location.href);
+						//findAllBoardFileOriginalNames();
+					}).catch(error => {
+						alert('파일 삭제 중 오류가 발생했습니다.');
+					})
+				}
+				
+				/*
+				* 파일 원본 이름 리스트 조회하기
+				*/
+				function findAllBoardFileOriginalNames() {
+					const id = /*[[ ${id} ]]*/ 0;
+					const url = `/api/boards/{id}/files`;
+					
+					fetch(url).then(response => {
+						if (!response.ok) {
+							throw new Error('Request failed...');
+						}
+						
+						return response.json();
+					}).then(json => {
+						let html = '';
+						if (json.length !== 0) {
+							html += `<label for="inp-type-5" class="col-sm-2 control-label">첨부파일</label>`;
+							json.forEach(json => {
+								html += `
+							              		<span style="margin-right: 20px;">>${json.originalName}</span>
+						    		`;
+							})
+							
+							
+						}
+						document.querySelector('.original-name-list').innerHTML = html;
+					})
 				}
 			/*]]>*/
 		</script>


### PR DESCRIPTION
## SSR(Server Side Rendering) vs CSR(Client Side Rendering)
 - SSR의 장점은 화면을 서버에서 보내주기 때문에 처음 화면이 나오는 것이 빨라 사용자 경험이 좋다는 것입니다. 대신 Interaction이 살짝 느리다는 단점이 있습니다.
 - CSR의 장단점은 SSR과 반대라고 볼 수 있습니다.
 - 그러므로 이를 상호보완하기 위해 초기에는 Model을 통해 서버에서 데이터를 보내주고 그 후 View에서 변경되는 사항은 클라이언트에서 비동기적으로 처리하는 게 좋다고 판단했습니다.

## 기능 추가 사항
 ### BoardFile Entity
  - Soft Delete를 할 수 있는 delete 메서드를 추가했습니다.

 ### BoardFile API Controller
  - 파일의 원본 이름 리스트를 조회하는 findAllBoardFileOriginalNames 메서드를 추가했습니다.
  - 파일을 삭제하는 deleteBoardFile 메서드를 추가했습니다.

 ### BoardFile OriginalName DTO
  - id필드를 추가하고, 생성자에도 추가했습니다.
    - 파일을 삭제하려면 파일 아이디가 필요하기 때문입니다.

 ### BoardFile Service
  - 파일을 삭제하는 deletedFile 메서드를 추가했습니다.

 ### Custom Board Repository Impl
  - BoardFile의 id도 함께 보내야하므로 id를 추가했습니다.

 ### write.html
  - 갱신된 파일 이름을 변경하기 위해 original-name-list 클래스를 추가했습니다.
  - 파일을 삭제하기 위해 버튼을 추가했습니다.
  - 파일을 삭제하기 위한 deleteFile 함수를 추가했습니다.
  - 갱신된 파일 이름 리스트를 조회하기 위한 findAllBoardFileOriginalNames 함수를 추가했습니다.
    - 원래 해당 클래스의 html만 변경하고 나머지는 유지하려고 했는데 deleteFile 함수를 실행하면 url이 바뀌게됩니다.
    - 백엔드를 위한 토이 프로젝트라서 아직 클라이언트 측은 부족한 부분이 많고 게시글 작성과 수정이 유사한 면을 가지고 있어 코드가 중복되는 부분이 많았기 때문에 하나의 html 파일에서 진행하다 보니 url 관리 문제가 생기는 것 같습니다.
    - 제목이나 내용 등을 수정하고 파일을 삭제하면 초기화되는 부정적인 경험이 있지만 해결 방도가 아직 없어 현재 url로
강제 이동하는 코드를 유지할 수 밖에 없었습니다. 추후 수정하겠습니다.

 ### 관련 이슈
 - #183

## 테스트 환경
 - **웹 사이트 환경**

## 기타 수정 사항
 ### BoardFile Service
  - insertFile 메서드의 매개변수에 final 키워드를 추가했습니다.

 ### Comment Repository
  - 이젠 사용하지 않는 메서드를 삭제했습니다.

 ### Custom Board Repository
  - 주석처리돼 이젠 사용하지 않는 메서드를 삭제했습니다.

 ### view.html
  - Delete를 수행하는 함수에도 Content-Type으로 application/json이 들어가 있었으므로 삭제했습니다.
  - 댓글을 삭제하는 함수에도 confirm을 통해 확인 후 지우도록 했습니다.