### PR TITLE
기능 추가: View에서 버튼으로 댓글을 수정하는 기능 추가(댓글 수정 시 댓글 입력 폼으로 이동 및 취소)

### DIFF
--- a/board/src/main/java/com/jk/board/entity/Comment.java
+++ b/board/src/main/java/com/jk/board/entity/Comment.java
@@ -51,7 +51,7 @@ public class Comment {
 	
 	private LocalDateTime modifiedDate;
 	
-	@ManyToOne(fetch = FetchType.LAZY)
+	@ManyToOne
 	@JoinColumn(name = "BOARD_ID", nullable = false)
 	private Board board;
 

--- a/board/src/main/resources/templates/board/view.html
+++ b/board/src/main/resources/templates/board/view.html
@@ -297,7 +297,7 @@
 									
 									<!-- Comment 관련 버튼 영역 -->
 									<div class="btn_wrap text-right col-sm-11">
-										<button type="button" class="btn btn-violet waves-effect waves-light">수정하기</button>
+										<button type="button" onclick="getComment(${obj.id});"class="btn btn-violet waves-effect waves-light">수정하기</button>
 										<button type="button" onclick="deleteComment(${obj.id});" class="btn btn-danger waves-effect waves-light">삭제하기</button>
 									</div>
 								</form>
@@ -307,6 +307,85 @@
 			});
 
 			document.querySelector('.comment-list').innerHTML = commentHtml;
+		}
+		
+		/*
+		* 댓글 수정을 위한 댓글 상세 정보 가져오기
+		*/
+		function getComment(commentId) {
+			const id = /*[[ ${id} ]]*/ 0;
+			const url = `/api/boards/${id}/comments/${commentId}`;
+			
+			fetch(url)
+			.then(response => {
+				if (!response.ok) {
+					throw new Error('Request failed...');
+				}
+				
+				return response.json();
+			}).then(json => {
+				if (json.id === commentId) {
+				    let	html = `
+					<form id="commentForm" class="form-horizontal form-view">
+						<div class="form-group">
+							<label for="commentWriter" class="col-sm-2 control-label">작성자</label>
+							<div class="col-sm-2">
+								<input type="text" value="${json.writer}" class="form-control" id="commentWriter" placeholder="작성자 이름" style="background-color: transparent;">
+							</div>
+						</div>
+						
+						<div class="form-group">
+							<label for="commentText" class="col-sm-2 control-label">댓글</label>
+							<div class="col-sm-9">
+								<textarea class="form-control" id="commentText" rows="3" placeholder="댓글 내용" style="background-color: transparent;">${json.comment}</textarea>
+							</div>
+						</div>
+						
+						<!-- Comment 관련 버튼 영역 -->
+						<div class="btn_wrap text-right col-sm-11">
+							<button type="button"  class="btn btn-violet waves-effect waves-light">수정하기</button>
+							<button type="button" onclick="cancelCommentUpdate();" class="btn btn-default waves-effect waves-light">취소하기</button>
+						</div>
+					</form>
+					`;
+					document.querySelector('.comments').innerHTML = html;
+					
+					const commentForm = document.getElementById('commentForm');
+					commentForm.commentText.focus();
+				}
+			}).catch(error => {
+				console.log(error);
+				alert('댓글 수정 시작 중 오류가 발생했습니다.')
+			})
+		}
+		
+		/*
+		* 댓글 수정 취소
+		*/
+		function cancelCommentUpdate() {
+			let html = `
+						<form id="commentForm" class="form-horizontal form-view">
+							<div class="form-group">
+								<label for="commentWriter" class="col-sm-2 control-label">작성자</label>
+								<div class="col-sm-2">
+									<input type="text" class="form-control" id="commentWriter" placeholder="작성자 이름" style="background-color: transparent;">
+								</div>
+							</div>
+							
+							<div class="form-group">
+								<label for="commentText" class="col-sm-2 control-label">댓글</label>
+								<div class="col-sm-9">
+									<textarea class="form-control" id="commentText" rows="3" placeholder="댓글 내용" style="background-color: transparent;"></textarea>
+								</div>
+							</div>
+							
+							<!-- Comment 관련 버튼 영역 -->
+							<div class="btn_wrap text-right col-sm-11">
+								<button type="button" onclick="writeComment();" class="btn btn-primary waves-effect waves-light">작성하기</button>
+							</div>
+						</form>
+						`;
+						document.querySelector('.comments').innerHTML = html;
 		}
 		
 		/*


### PR DESCRIPTION
## 기능 추가 사항
 ### view.html
  - 수정하기 버튼을 누를 시 현재 댓글의 정보가 입력폼에 복사되는 기능을 추가했습니다.
  - 그 후 취소하기를 누르면 다시 원래 댓글 작성 폼으로 변경되는 기능을 추가했습니다.

### 관련 이슈
  - #149

## 테스트 환경
 - **웹 사이트 환경**

## 기타 수정 사항
 ### Comment Entity
  - `Type definition error: [simple type, class org.hibernate.proxy.pojo.bytebuddy.ByteBuddyInterceptor]`
  오류가 발생해서 일단 임시 조치로 FetchType을 EAGER로 변경했습니다.