### PR TITLE
기능 추가: View에서 버튼으로 댓글을 수정하는 기능 추가(FetchType.Lazy 오류 해결)

### DIFF
--- a/board/src/main/java/com/jk/board/dto/CommentResponse.java
+++ b/board/src/main/java/com/jk/board/dto/CommentResponse.java
@@ -2,7 +2,6 @@ package com.jk.board.dto;
 
 import java.time.LocalDateTime;
 
-import com.jk.board.entity.Board;
 import com.jk.board.entity.Comment;
 
 import lombok.AccessLevel;
@@ -19,7 +18,6 @@ public class CommentResponse {
 	private boolean isDeleted;
 	private LocalDateTime createdDate;
 	private LocalDateTime modifiedDate;
-	private Board board;
 	
 	public CommentResponse(final Comment comment) {
 		this.id = comment.getId();
@@ -28,7 +26,6 @@ public class CommentResponse {
 		this.isDeleted = comment.getIsDeleted();
 		this.createdDate = comment.getCreatedDate();
 		this.modifiedDate = comment.getModifiedDate();
-		this.board = comment.getBoard();
 	}
 	
 	public boolean getIsDeleted() {

--- a/board/src/main/java/com/jk/board/entity/Comment.java
+++ b/board/src/main/java/com/jk/board/entity/Comment.java
@@ -51,7 +51,7 @@ public class Comment {
 	
 	private LocalDateTime modifiedDate;
 	
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "BOARD_ID", nullable = false)
 	private Board board;
 


### PR DESCRIPTION
## Type definition error: [simple type, class org.hibernate.proxy.pojo.bytebuddy.ByteBuddyInterceptor]
 - 해당 오류는 연관관계가 지연 로딩일 때 발생하는 오류로 직렬화를 할 때 해당 객체가 아닌 프록시로 감싸져있는 hibernateLazyInitializer를 직렬화해 생기는 오류입니다.
 - 저의 엔티티 자체를 보내는 게 아니라 DTO를 통해서 처리를 하고 있었는데 왜 수정을 하려고 할 때 그런 오류가 나는 지를 확인해보니 무의식적으로 Comment Response DTO에 Board 객체를 포함하고 있어서 오류가 나는 것 같습니다.
 - 앞으로 DTO를 사용할 때는 확실히 사용하는 것만 포함하는 것이 리소스적으로도 좋고 코드 안정성이 높아지기 때문에 주의해서 사용하는 것이 좋겠습니다.

## 코드 수정 사항
 ### Comment Entity
  - `@ManyToOne` 어노테이션의 fetch 옵션을 FetchType.LAZY로 복구하였습니다.

### Comment Response Entity
  - Board 필드를 삭제했습니다.

### 관련 이슈
 - #149

## 테스트 환경
 - **웹 사이트 환경**