### PR TITLE
코드 리팩토링: 회원가입 및 로그인 기능 구현 전 전반적인 코드 리팩토링(Service에서 트랜잭션)

### DIFF
--- a/board/src/main/java/com/jk/board/service/BoardFileService.java
+++ b/board/src/main/java/com/jk/board/service/BoardFileService.java
@@ -24,6 +24,7 @@ import com.jk.board.repository.BoardRepository;
 
 import lombok.RequiredArgsConstructor;
 
+@Transactional
 @RequiredArgsConstructor
 @Service
 public class BoardFileService {
@@ -34,7 +35,6 @@ public class BoardFileService {
 	private final BoardFileRepository boardFileRepository;
 	private final BoardRepository boardRepository;
 
-	@Transactional
 	public Map<String, Object> saveFiles(final Long boardId, final BoardRequest boardRequest) throws Exception {
 		List<MultipartFile> multipartFiles = boardRequest.getMultipartFiles();
 		
@@ -64,7 +64,7 @@ public class BoardFileService {
 								.board(boardRepository.findById(boardId).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND)))
 								.build();
 						
-						Long fileId = insertFile(boardFileDto.toEntity());
+						Long fileId = boardFileRepository.save(boardFileDto.toEntity()).getId();
 						
 						try {
 							InputStream fileStream = file.getInputStream();
@@ -88,16 +88,10 @@ public class BoardFileService {
 		
 		return result;
 	}
-
-	@Transactional
-	private Long insertFile(final BoardFile boardFile) {
-		return boardFileRepository.save(boardFile).getId();
-	}
 	
 	/*
 	 * 게시판 파일 삭제
 	 */
-	@Transactional
 	public Long deleteFile(final Long boardFileId) {
 		BoardFile boardFile = boardFileRepository.findById(boardFileId).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
 		

--- a/board/src/main/java/com/jk/board/service/BoardService.java
+++ b/board/src/main/java/com/jk/board/service/BoardService.java
@@ -20,6 +20,7 @@ import com.jk.board.repository.BoardRepository;
 
 import lombok.RequiredArgsConstructor;
 
+@Transactional
 @RequiredArgsConstructor
 @Service
 public class BoardService {
@@ -32,12 +33,11 @@ public class BoardService {
 	/*
 	 * 게시글 생성
 	 */
-	@Transactional
 	public Long writeBoard(final BoardRequest boardRequest) throws Exception {
 		Board board = boardRepository.save(boardRequest.toEntity());
 		Long id = board.getId();
 		
-		saveFiles(id, boardRequest);
+		boardFileService.saveFiles(id, boardRequest);
 		
 		return id;
 	}
@@ -45,27 +45,18 @@ public class BoardService {
 	/*
 	 * 게시글 수정
 	 */
-	@Transactional
 	public Long updateBoard(final Long id, final BoardRequest boardRequest) throws Exception {
 		Board board = boardRepository.findById(id).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
 		board.update(boardRequest.getTitle(), boardRequest.getContent(), boardRequest.getWriter());
 		
-		saveFiles(id, boardRequest);
+		boardFileService.saveFiles(id, boardRequest);
 		
 		return id;
 	}
 	
 	/*
-	 * 파일 저장
-	 */
-	private void saveFiles(final Long id, final BoardRequest boardRequest) throws Exception {
-		boardFileService.saveFiles(id, boardRequest);
-	}
-	
-	/*
 	 * 게시글 삭제
 	 */
-	@Transactional
 	public Long deleteBoard(final Long id) {
 		Board board = boardRepository.findById(id).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
 		board.delete();
@@ -76,6 +67,7 @@ public class BoardService {
 	/*
 	 * 게시글 리스트 조회 (페이지네이션)
 	 */
+	@Transactional(readOnly = true)
 	public Map<String, Object> findAllBoards(final BoardCommonParams params) {
 		int count = boardMapper.countBoard(params);
 
@@ -97,7 +89,7 @@ public class BoardService {
 	/*
 	 * 게시글 상세정보 조회
 	 */
-	@Transactional
+	@Transactional(readOnly = true)
 	public BoardResponse findBoardById(final Long id) {
 		Board board = boardRepository.findById(id).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
 		board.increaseHits();

--- a/board/src/main/java/com/jk/board/service/CommentService.java
+++ b/board/src/main/java/com/jk/board/service/CommentService.java
@@ -14,21 +14,19 @@ import com.jk.board.exception.ErrorCode;
 import com.jk.board.repository.BoardRepository;
 import com.jk.board.repository.CommentRepository;
 
+import lombok.RequiredArgsConstructor;
+
+@Transactional
+@RequiredArgsConstructor
 @Service
 public class CommentService {
 
 	private final CommentRepository commentRepository;
 	private final BoardRepository boardRepository;
-
-	public CommentService(final CommentRepository commentRepository, final BoardRepository boardRepository) {
-		this.commentRepository = commentRepository;
-		this.boardRepository = boardRepository;
-	}
 	
 	/*
 	 * 댓글 생성
 	 */
-	@Transactional
 	public Long writeComment(final Long boardId, final CommentRequest commentRequest) {
 		Board board = boardRepository.findById(boardId).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
 
@@ -42,7 +40,6 @@ public class CommentService {
 	/*
 	 * 댓글 수정
 	 */
-	@Transactional
 	public Long updateComment(final Long id, final CommentRequest commentRequest) {
 		Comment comment = commentRepository.findById(id).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
 		comment.update(commentRequest.getComment(), commentRequest.getWriter());
@@ -53,7 +50,6 @@ public class CommentService {
 	/*
 	 * 댓글 삭제
 	 */
-	@Transactional
 	public Long deleteComment(final Long id) {
 		Comment comment = commentRepository.findById(id).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
 		comment.delete();
@@ -64,6 +60,7 @@ public class CommentService {
 	/*
 	 * 댓글 리스트 조회
 	 */
+	@Transactional(readOnly = true)
 	public Page<CommentResponse> findAllComments(final Long boardId, final Pageable pageable) {
 		Board board = boardRepository.findById(boardId).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
 		
@@ -73,7 +70,7 @@ public class CommentService {
 	/*
 	 * 댓글 상세정보 조회
 	 */
-	@Transactional
+	@Transactional(readOnly = true)
 	public CommentResponse findCommentById(final Long id) {
 		Comment comment = commentRepository.findById(id).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
 		


### PR DESCRIPTION
## Transaction
 ### Spring AOP 프록시
 - `@Transactional`은 Spring AOP의 프록시 객체를 통해서 적용됩니다.
 - `@Transactional`이 하나라도 있는 클래스는 프록시 객체가 생성됩니다.
 - `@Transactional`이 있다면 프록시 객체가 인터셉터로 트랜잭션을 처리해주는 데 다른 클래스는 상관 없지만 자기 클래스 내에서호출하게 될 경우 직접 객체에 접근하기 때문에 트랜잭션이 제대로 유지되지 않습니다.
 - 그러므로, 다른 클래스를 만들고 거기에 메서드를 만드는 방법도 있지만 현재 메서드가 크지 않고 수정될 가능성도 낮기 때문에 호출하는 메서드에 삽입하는 방향으로 진행했습니다.
 
 ### readOnly = true
 - 읽기 전용으로 처리할 수 있고, 특히 저는 JPA를 사용하기 때문에 Flush Mode가 MANUAL 스냅 샷을 통한 Dirty Checking 비활성화로 성능면에서 좋을 수 있습니다.
 - 하지만 `@Transactional`을 코드에 있는 주석을 확인 해보니 이 속성은 읽기 전용이라는 힌트만 줄 뿐 드라이버나 DB에 따라서 쓰기 작업도 작동할 수 있고, 강제할 수 없다라고 적혀있었습니다.
 - 그리고 현재 21c Oracle 드라이버를 사용중인데 12c 버전부터 강제할 수 없다고 나와있습니다.
   - **출처:** https://github.com/spring-projects/spring-framework/issues/19774
 - 기능을 강제하지 못하더라도 속성을 통해 이 메서드가 읽기 전용이라는 걸 알려줄 수 있고, 모든 메서드에서 트랜잭션을 필요로하므로 클래스에 기본 값인 `@Transactional`을 설정하고 읽기 전용 메서드에만 속성을 추가하는 방향으로 진행하겠습니다.

## 코드 리팩토링 사항
 ### BoardFile Service
  - 모든 메서드에 `@Transactional`이 필요하기 때문에 클래스에 선언했습니다.
  - insertFile 메서드를 saveFiles 메서드 안에 옮겼습니다.

 ### Board Service
  - 모든 메서드에 `@Transactional`이 필요하기 때문에 클래스에 선언했습니다.
    - readOnly 속성이 true가 필요한 메서드들은 메서드 단위에 추가했습니다.
  - saveFiles 메서드를 wirteBoard와 updateBoard 안으로 옮겼습니다.

 ### Comment Service
  - 모든 메서드에 `@Transactional`이 필요하기 때문에 클래스에 선언했습니다.
    - readOnly 속성이 true가 필요한 메서드들은 메서드 단위에 추가했습니다.

 ### 관련 이슈
  - #204

## 테스트 환경
 - **웹 사이트 환경**