### PR TITLE
코드 리팩토링: 회원가입 및 로그인 기능 구현 전 전반적인 코드 리팩토링(생성자 DI 접근 제어자)

### DIFF
--- a/board/src/main/java/com/jk/board/controller/BoardFileApiController.java
+++ b/board/src/main/java/com/jk/board/controller/BoardFileApiController.java
@@ -12,10 +12,9 @@ import com.jk.board.dto.BoardFileOriginalName;
 import com.jk.board.repository.CustomBoardRepository;
 import com.jk.board.service.BoardFileService;
 
-import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+@RequiredArgsConstructor
 @RequestMapping("/api")
 @RestController
 public class BoardFileApiController {

--- a/board/src/main/java/com/jk/board/controller/BoardFileController.java
+++ b/board/src/main/java/com/jk/board/controller/BoardFileController.java
@@ -18,10 +18,9 @@ import com.jk.board.exception.ErrorCode;
 import com.jk.board.repository.BoardFileRepository;
 
 import jakarta.servlet.http.HttpServletResponse;
-import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+@RequiredArgsConstructor
 @Controller
 public class BoardFileController {
 	

--- a/board/src/main/java/com/jk/board/controller/BoardViewController.java
+++ b/board/src/main/java/com/jk/board/controller/BoardViewController.java
@@ -9,10 +9,9 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 import com.jk.board.repository.CustomBoardRepository;
 
-import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+@RequiredArgsConstructor
 @RequestMapping("/board")
 @Controller
 public class BoardViewController {

--- a/board/src/main/java/com/jk/board/repositoryImpl/CustomBoardRepositoryImpl.java
+++ b/board/src/main/java/com/jk/board/repositoryImpl/CustomBoardRepositoryImpl.java
@@ -10,10 +10,9 @@ import com.jk.board.repository.CustomBoardRepository;
 
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
-import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+@RequiredArgsConstructor
 @Repository
 public class CustomBoardRepositoryImpl implements CustomBoardRepository {
 


### PR DESCRIPTION
## 생성자 주입 시 접근 제어자
 - private 생성자여도 Spring DI 컨테이너에서 잘 찾아서 주입을 해주지만 Spring이라는 프레임워크에 종속될 수 있습니다.
 -  POJO 테스트 진행 시 외부에서 의존관계를 없어 사실상 필드 주입과 같은 효과가 나타납니다.
    - 스프링 테스트 파일 같은 패키지기 때문에 protected로도 가능하지만 public이 컨벤션이기 때문에 public으로 하겠습니다.

## 코드 리팩토링 사항
 - BoardFile API, BoardFile, Board View Controller와 Custom Board Repository Impl의 `@RequiredArgsConstructor`의 접근 레벨을 public으로 변경했습니다.
 - **관련 이슈:** #204

## 테스트 환경
 - **API 테스트 환경**