### PR TITLE
코드 리팩토링: 회원가입 및 로그인 기능 구현 전 전반적인 코드 리팩토링 (DTO의 기본 생성자)

### DIFF
--- a/board/src/main/java/com/jk/board/dto/BoardFileDTO.java
+++ b/board/src/main/java/com/jk/board/dto/BoardFileDTO.java
@@ -3,13 +3,12 @@ package com.jk.board.dto;
 import com.jk.board.entity.Board;
 import com.jk.board.entity.BoardFile;
 
-import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
 public class BoardFileDTO {
 
 	private Long id;

--- a/board/src/main/java/com/jk/board/dto/BoardFileOriginalName.java
+++ b/board/src/main/java/com/jk/board/dto/BoardFileOriginalName.java
@@ -1,12 +1,11 @@
 package com.jk.board.dto;
 
-import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
 public class BoardFileOriginalName {
 
 	private Long id;

--- a/board/src/main/java/com/jk/board/dto/BoardRequest.java
+++ b/board/src/main/java/com/jk/board/dto/BoardRequest.java
@@ -6,13 +6,12 @@ import org.springframework.web.multipart.MultipartFile;
 
 import com.jk.board.entity.Board;
 
-import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
 public class BoardRequest {
 
 	private String title;

--- a/board/src/main/java/com/jk/board/dto/BoardResponse.java
+++ b/board/src/main/java/com/jk/board/dto/BoardResponse.java
@@ -4,12 +4,11 @@ import java.time.LocalDateTime;
 
 import com.jk.board.entity.Board;
 
-import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
 public class BoardResponse {
 
 	private Long id;

--- a/board/src/main/java/com/jk/board/dto/CommentRequest.java
+++ b/board/src/main/java/com/jk/board/dto/CommentRequest.java
@@ -2,12 +2,11 @@ package com.jk.board.dto;
 
 import com.jk.board.entity.Comment;
 
-import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
 public class CommentRequest {
 
 	private String comment;

--- a/board/src/main/java/com/jk/board/dto/CommentResponse.java
+++ b/board/src/main/java/com/jk/board/dto/CommentResponse.java
@@ -4,12 +4,11 @@ import java.time.LocalDateTime;
 
 import com.jk.board.entity.Comment;
 
-import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
 public class CommentResponse {
 
 	private Long id;


### PR DESCRIPTION
## DTO의 기본 생성자
 - 저는 개발 초기에 Entity와 DTO의 큰 차이를 몰라서 Entity처럼 습관적으로 DTO에 기본 생성자를 protected로 생성했습니다. 그러다 코드를 리팩토링하는 과정에서 기본 생성자가 필요 없어 보였고 이에 대해 공부를 시작했습니다.
 - Jackson에서 제공하는 ObjectMapper는 기본 생성자를 꼭 필요로 한다고 했습니다. 하지만, 제가 테스트했을 때는 달랐습니다. Board Response DTO를 제외한 나머지 DTO는 기본 생성자 생성 어노테이션을 제거해도 멀쩡하게 돌아갔습니다. (Board Response DTO는 후술 하겠습니다.)
 - 그 이유는 Springboot에 있었습니다.
   - Springboot는 jackson-module-parameter-names이라는 모듈을 기본적으로 가지고 있는데 이는 기본 생성자가 없어도 역직렬화를 수행하게 해주는 모듈입니다. 
     - 이 모듈은 기본 생성자가 없는 경우 필드에 데이터를 넣을 수 있는 다른 루트를 찾게 되는데 인자가 있는 생성자가 그 대상이 됩니다. 그 생성자를 통해 역직렬화를 진행합니다.
     - 저는 Springboot를 통해 개발하고 있었기 때문에 문제가 없던 것이었습니다.
     - 이에 관련해 테스트를 잘 정리해 놓은 블로그가 있어서 URL을 남겨놓겠습니다.
       - https://beaniejoy.tistory.com/75
       - https://beaniejoy.tistory.com/76
 - 그래서 프레임워크에 종속되면 안되기 때문에 기본 생성자를 public으로 다 생성하기로 결정했습니다.
 - 마지막으로 Board Response DTO의 경우 게시글 페이지네이션이 MyBatis로 개발했기 때문에 이것과 관련 있을 수도 있다고 생각합니다. 추후 JPA로 마이그레이션할 에정이기 때문에 그 때 테스트해보고 확실하게 알아보겠습니다.
   - **(추가 사항)** MyBatis는 DB 쿼리의 결과를 저장해야할 Java 객체를 생성해야합니다. 이 과정이 ResultMapping인데 ResultMapping을 할 때 ObjectFactory가 기본 생성자를 통해 인스턴스를 생성합니다. 그 후 리플렉션을 통해 객체의 구조를 분석하고 쿼리의 결과를 적절한 필드에 매핑합니다.
   - 이런 이유 때문에 MyBatis에서는 기본 생성자를 필요로 합니다.

## 코드 리팩토링 사항
 - DTO의 기본 생성자 접근 레벨을 public으로 변경했습니다.
 - **관련 이슈:** #204

## 테스트 환경
 - **웹 사이트 환경**