### PR TITLE
코드 리팩토링: 회원가입 및 로그인 기능 구현 전 전반적인 코드 리팩토링(Custom Board File Repo 상속)

### DIFF
--- a/board/src/main/java/com/jk/board/controller/BoardFileApiController.java
+++ b/board/src/main/java/com/jk/board/controller/BoardFileApiController.java
@@ -9,7 +9,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.jk.board.dto.BoardFileOriginalName;
-import com.jk.board.repository.CustomBoardFileRepository;
 import com.jk.board.service.BoardFileService;
 
 import lombok.RequiredArgsConstructor;
@@ -21,8 +20,6 @@ public class BoardFileApiController {
 
 	private final BoardFileService boardFileService;
 	
-	private final CustomBoardFileRepository customBoardFileRepository;
-	
 	/*
 	 * 파일 원본 이름 리스트 조회 메서드
 	 * 
@@ -32,7 +29,7 @@ public class BoardFileApiController {
 	 */
 	@GetMapping("/boards/{boardId}/files")
 	public List<BoardFileOriginalName> findAllBoardFileOriginalNames(@PathVariable final Long boardId) {
-		return customBoardFileRepository.selectBoardFileOriginalName(boardId);
+		return boardFileService.selectBoardFileOriginalName(boardId);
 	}
 	
 	/*

--- a/board/src/main/java/com/jk/board/controller/BoardViewController.java
+++ b/board/src/main/java/com/jk/board/controller/BoardViewController.java
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
-import com.jk.board.repository.CustomBoardFileRepository;
+import com.jk.board.service.BoardFileService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -19,8 +19,8 @@ import lombok.RequiredArgsConstructor;
  */
 public class BoardViewController {
 	
-	private final CustomBoardFileRepository customBoardFileRepository;
-
+	private final BoardFileService boardFileService;
+	
 	/*
 	 * 게시글 리스트 페이지
 	 */
@@ -37,7 +37,7 @@ public class BoardViewController {
 		model.addAttribute("id", id);
 		// 수정 페이지일 경우
 		if (id != null) {
-			model.addAttribute("boardFileOriginalName", customBoardFileRepository.selectBoardFileOriginalName(id));
+			model.addAttribute("boardFileOriginalName", boardFileService.selectBoardFileOriginalName(id));
 		}
 		return "board/write";
 	}
@@ -48,7 +48,7 @@ public class BoardViewController {
 	@GetMapping("/view/{id}")
 	public String viewBoard(@PathVariable final Long id, Model model) {
 		model.addAttribute("id", id);
-		model.addAttribute("boardFile", customBoardFileRepository.selectBoardFileDetail(id));
+		model.addAttribute("boardFile", boardFileService.selectBoardFileDetail(id));
 		
 		return "board/view";
 	}

--- a/board/src/main/java/com/jk/board/repository/BoardFileRepository.java
+++ b/board/src/main/java/com/jk/board/repository/BoardFileRepository.java
@@ -4,6 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.jk.board.entity.BoardFile;
 
-public interface BoardFileRepository extends JpaRepository<BoardFile, Long> {
+public interface BoardFileRepository extends JpaRepository<BoardFile, Long>, CustomBoardFileRepository {
 
 }

--- a/board/src/main/java/com/jk/board/service/BoardFileService.java
+++ b/board/src/main/java/com/jk/board/service/BoardFileService.java
@@ -15,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.jk.board.dto.BoardFileDTO;
+import com.jk.board.dto.BoardFileOriginalName;
 import com.jk.board.dto.BoardRequest;
 import com.jk.board.entity.BoardFile;
 import com.jk.board.exception.CustomException;
@@ -39,7 +40,6 @@ public class BoardFileService {
 	// 파일 저장 메서드
 	public Map<String, Object> saveFiles(final Long boardId, final BoardRequest boardRequest) throws Exception {
 		List<MultipartFile> multipartFiles = boardRequest.getMultipartFiles();
-		
 		Map<String, Object> result = new HashMap<>();
 		
 		// 업로드된 파일들의 id를 저장할 list
@@ -96,7 +96,7 @@ public class BoardFileService {
 	}
 	
 	/*
-	 * 게시판 파일 삭제
+	 * 게시판 파일 삭제 메서드
 	 */
 	public Long deleteFile(final Long boardFileId) {
 		BoardFile boardFile = boardFileRepository.findById(boardFileId).orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND));
@@ -104,4 +104,21 @@ public class BoardFileService {
 		boardFile.delete();
 		return boardFileId;
 	}
+
+	/*
+	 * 첨부 파일들의 원본 이름 반환 메서드
+	 * CustomBoardFileRepository 상속을 통해 받아 온 메서드
+	 */
+	public List<BoardFileOriginalName> selectBoardFileOriginalName(Long boardId) {
+		return boardFileRepository.selectBoardFileOriginalName(boardId);
+	}
+
+	/*
+	 * 첨부 파일 반환 메서드
+	 * CustomBoardFileRepository 상속을 통해 받아 온 메서드
+	 */
+	public Object selectBoardFileDetail(Long boardId) {
+		return boardFileRepository.selectBoardFileDetail(boardId);
+	}
+	
 }


### PR DESCRIPTION
## Custom Repository
 - #184 Pull Request를 확인해보면 추가 상속을 통해 Custom Repository를 통합해 하나의 Service에서 사용할 수 있게됩니다.
 - 이렇게 했을 때의 장점으론
   - SRP 원칙을 준수할 수 있습니다.
   - DI가 용이해집니다.
 - 그리고 Controller에서는 Servcie를 통해 값을 처리하는 게 맞다고 생각되기 때문에 Repository가 아닌 Service로 처리하도록 변경했습니다.

## 코드 리팩토링 사항
### Board File API Controller
  - CustomBoardFileRepository를 제거하고 BoardFileService를 통해 처리하도록 변경했습니다.

### Board File Repository
  - CustomBoardFileRepository 인터페이스를 상속하는 부분을 추가했습니다.

### Board File Service
  - CustomBoardFileRepsoitry 상속을 통해 받아 온 메서드를 사용하는 메서드를 추가했습니다.

### Board View API Controller
  - CustomBoardFileRepository가 아닌 BoardFileService를 통해 값을 처리하도록 변경했습니다.

### 관련 이슈
  - #204

## 테스트 환경
 - **웹 사이트 테스트 환경**