### PR TITLE
코드 리팩토링: 회원가입 및 로그인 기능 구현 전 전반적인 코드 리팩토링 (JPA로 마이그레이션 COUNT 부분)

### DIFF
--- a/board/src/main/java/com/jk/board/repository/BoardRepository.java
+++ b/board/src/main/java/com/jk/board/repository/BoardRepository.java
@@ -4,6 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.jk.board.entity.Board;
 
-public interface BoardRepository extends JpaRepository<Board, Long> {
+public interface BoardRepository extends JpaRepository<Board, Long>, CustomBoardRepository {
 
 }

--- a/board/src/main/java/com/jk/board/repository/CustomBoardRepository.java
+++ b/board/src/main/java/com/jk/board/repository/CustomBoardRepository.java
@@ -1,0 +1,13 @@
+package com.jk.board.repository;
+
+public interface CustomBoardRepository {
+	Long countBoardDefault();
+	
+	Long countBoardByAllSearchType(final String keywordForSearch);
+	
+	Long countBoardByTitle(final String keywordForSearch);
+	
+	Long countBoardByContent(final String keywordForSearch);
+	
+	Long countBoardByWriter(final String keywordForSearch);
+}

--- a/board/src/main/java/com/jk/board/repositoryImpl/CustomBoardRepositoryImpl.java
+++ b/board/src/main/java/com/jk/board/repositoryImpl/CustomBoardRepositoryImpl.java
@@ -1,0 +1,97 @@
+package com.jk.board.repositoryImpl;
+
+import org.springframework.stereotype.Repository;
+
+import com.jk.board.repository.CustomBoardRepository;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Repository
+public class CustomBoardRepositoryImpl implements CustomBoardRepository {
+
+	@PersistenceContext
+	private EntityManager em;
+	
+	/*
+	 * 검색 키워드가 없을 때 게시글 수 조회 메서드
+	 */
+	public Long countBoardDefault() {
+		String jpql = "SELECT COUNT(b) " +
+					  "FROM Board b " +
+					  "WHERE b.isDeleted = :isDeleted";
+		
+		Long result = em.createQuery(jpql, Long.class)
+						.setParameter("isDeleted", false)
+						.getSingleResult();
+		
+		return result;
+	}
+	
+	/*
+	 * 제목, 내용, 작성자를 모두 포함한 게시글 수 조회 메서드
+	 */
+	@Override
+	public Long countBoardByAllSearchType(final String keywordForSearch) {
+		String jpql = "SELECT COUNT(b) " +
+					  "FROM Board b " +
+					  "WHERE b.isDeleted = :isDeleted " + 
+					  "AND (b.title LIKE '%' || :keywordForSearch || '%' " +
+					  "OR b.content LIKE '%' || :keywordForSearch || '%' " +
+					  "OR b.writer LIKE '%' || :keywordForSearch || '%') ";
+		
+		Long result = em.createQuery(jpql, Long.class)
+						.setParameter("isDeleted", false)
+						.setParameter("keywordForSearch", keywordForSearch)
+						.getSingleResult();
+		
+		return result;
+	}
+
+	/*
+	 * 제목 게시글 수 검색
+	 */
+	@Override
+	public Long countBoardByTitle(final String keywordForSearch) {
+		return countBoardTemplate("title", keywordForSearch);
+	}
+
+	/*
+	 * 내용 게시글 수 검색
+	 */
+	@Override
+	public Long countBoardByContent(final String keywordForSearch) {
+		return countBoardTemplate("content", keywordForSearch);
+	}
+
+	/*
+	 * 작성자 게시글 수 검색
+	 */
+	@Override
+	public Long countBoardByWriter(final String keywordForSearch) {
+		return countBoardTemplate("writer", keywordForSearch);
+	}
+	
+	/*
+	 * 게시글 수 검색 템플릿
+	 */
+	private Long countBoardTemplate(String searchType, String keywordForSearch) {
+		String jpql = "SELECT COUNT(b) " +
+					  "FROM Board b " +
+					  "WHERE b.isDeleted = :isDeleted " +
+					  "AND (CASE WHEN :searchType = 'title' THEN b.title " +
+	                  "          WHEN :searchType = 'content' THEN TO_CHAR(b.content) " +
+	                  "          WHEN :searchType = 'writer' THEN b.writer END) " +
+	                  "LIKE '%' || :keywordForSearch || '%'";
+		
+		Long result = em.createQuery(jpql, Long.class)
+						.setParameter("isDeleted", false)
+						.setParameter("searchType", searchType)
+						.setParameter("keywordForSearch", keywordForSearch)
+						.getSingleResult();
+	
+		return result;
+	}
+}

--- a/board/src/main/java/com/jk/board/service/BoardService.java
+++ b/board/src/main/java/com/jk/board/service/BoardService.java
@@ -69,13 +69,27 @@ public class BoardService {
 	 */
 	@Transactional(readOnly = true)
 	public Map<String, Object> findAllBoards(final BoardCommonParams params) {
-		int count = boardMapper.countBoard(params);
-
-		if (count < 1) {
+		Long count = 0L;
+		// 검색어가 있을 때
+		if (params.getKeywordForSearch() != "") {
+			if (params.getSearchType().equals("")) { // 전체 선택
+				count = boardRepository.countBoardByAllSearchType(params.getKeywordForSearch());
+			} else if (params.getSearchType().equals("title")) { // 제목 선택
+				count = boardRepository.countBoardByTitle(params.getKeywordForSearch());
+			} else if (params.getSearchType().equals("content")) { // 내용 선택
+				count = boardRepository.countBoardByContent(params.getKeywordForSearch());
+			} else if (params.getSearchType().equals("writer")) { // 작성자 선택
+				count = boardRepository.countBoardByWriter(params.getKeywordForSearch());
+			}
+		} else { // 검색어가 없을 때
+			count = boardRepository.countBoardDefault();
+		}
+		
+		if (count < 1L) {
 			return Collections.emptyMap();
 		}
 		
-		Pagination pagination = new Pagination(count, params);
+		Pagination pagination = new Pagination(count.intValue(), params);
 		params.setPagination(pagination);
 		
 		List<BoardResponse> list = boardMapper.findAllBoards(params);


### PR DESCRIPTION
## 코드 리팩토링 사항
 ### Board Repository
  - CustomBoardRepository를 상속했습니다.

 ### Board Service
  - JPA의 COUNT로 변경했습니다.
    - JPA는 COUNT를 Long 래퍼 클래스로 반환하기 때문에 Pagination에 들어가기 전에 int로 바꿔줬습니다. - 값이 크지 않아 아직은 상관 없겠지만 추후에 다시 리팩토링하면서 어떤 걸 변경할지 고민하겠습니다.

 ### Custom Board Repository
  - MyBatis와 다르게 JPA에서 JPQL로 조건문을 처리하는 건 너무나도 복잡하므로 상황에 맞는 메서드를 만들고 Service에서 비지니스 로직에 맞게 변경하는 방식으로 변경했습니다.

 ### Custom Board Repository Impl
  - 조건에 맞는 메서드를 구현했습니다.
    - 제목과 내용과 작가는 비슷하기 때문에 private 메서드를 만든 후 CASE WHEN TEHN 연산을 통해 조건에 맞게 처리했습니다.
      - CLOB 자료형은 CASE WHEN THEN을 사용할 수 없기 때문에 TO_CHAR() 함수로 변경 후에 사용했습니다.

 ### 관련 이슈
  - **#204**

## 테스트 환경
 - **웹 사이트 환경**