### PR TITLE
기능 추가: 로그인 기능 추가 (Spring Security 및 회원 저장 API 기능 추가)

### DIFF
--- a/board/build.gradle
+++ b/board/build.gradle
@@ -28,7 +28,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.bgee.log4jdbc-log4j2:log4jdbc-log4j2-jdbc4.1:1.16'
 	implementation group: 'com.oracle.database.jdbc', name: 'ojdbc11', version: '21.3.0.0'
-	implementation("org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.2")
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6:3.1.1.RELEASE'
 	implementation 'commons-io:commons-io:2.11.0'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/board/src/main/java/com/jk/board/config/SecurityConfig.java
+++ b/board/src/main/java/com/jk/board/config/SecurityConfig.java
@@ -1,0 +1,37 @@
+package com.jk.board.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+
+/*
+ * 모든 요청 URL이 스프링 시큐리티의 제어를 받도록 만드는 어노테이션이다.
+ * 어노테이션을 사용하면 내부적으로 SpringSecurityFilterChain이 동작하여 URL 필터가 적용된다.
+ */
+@EnableWebSecurity
+@Configuration
+public class SecurityConfig {
+	
+	@Bean
+	// 스프링 시큐리티의 세부 설정은 SecurityFilterChain 빈을 생성하여 설정할 수 있다.
+	public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
+		
+		// 모든 인증(Authentication)되지 않은 요청을 허락한다.
+		// 즉, 로그인을 하지 않더라도 모든 페이지에 접근이 가능하다. 
+		httpSecurity.authorizeHttpRequests((authorizeHttpRequests) -> authorizeHttpRequests
+				.requestMatchers(new AntPathRequestMatcher("/**")).permitAll());
+		
+		return httpSecurity.csrf().disable().build();
+	}
+	
+	@Bean
+	PasswordEncoder passwordEncoder() {
+		return new BCryptPasswordEncoder();
+	}
+
+}

--- a/board/src/main/java/com/jk/board/controller/MemberApiController.java
+++ b/board/src/main/java/com/jk/board/controller/MemberApiController.java
@@ -1,0 +1,31 @@
+package com.jk.board.controller;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.jk.board.dto.MemberRequest;
+import com.jk.board.service.MemberService;
+
+import lombok.RequiredArgsConstructor;
+
+//@RequiredArgsConstructor
+@RequestMapping("/api")
+@RestController
+public class MemberApiController {
+
+	private final MemberService memberService;
+	
+	public MemberApiController(final MemberService service) {
+		this.memberService = service;
+	}
+	
+	/*
+	 * 회원 저장 메서드
+	 */
+	@PostMapping("/members")
+	public Long create(@RequestBody final MemberRequest memberRequest) {
+		return memberService.join(memberRequest);
+	}
+}

--- a/board/src/main/java/com/jk/board/dto/MemberRequest.java
+++ b/board/src/main/java/com/jk/board/dto/MemberRequest.java
@@ -1,0 +1,29 @@
+package com.jk.board.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MemberRequest {
+
+	private String memberName;
+	private String password;
+	private String email;
+	private boolean isDeleted;
+	
+	public boolean getIsDeleted() {
+		return this.isDeleted;
+	}
+
+	@Builder
+	public MemberRequest(String memberName, String password, String email, boolean isDeleted) {
+		super();
+		this.memberName = memberName;
+		this.password = password;
+		this.email = email;
+		this.isDeleted = isDeleted;
+	}
+	
+}

--- a/board/src/main/java/com/jk/board/entity/Member.java
+++ b/board/src/main/java/com/jk/board/entity/Member.java
@@ -1,0 +1,64 @@
+package com.jk.board.entity;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.SequenceGenerator;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+@SequenceGenerator(
+		name = "MEMBER_ID_SEQ_GENERATOR",
+		sequenceName = "MEMBER_ID_SEQ",
+		initialValue = 1,
+		allocationSize = 1
+		)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Member {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "MEMBER_ID_SEQ_GENERATOR")
+	@Column(name = "MEMBER_ID")
+	private Long id;
+	
+	@Column(nullable = false, unique = true)
+	private String memberName;
+	
+	@Column(nullable = false)
+	private String password;
+	
+	@Column(nullable = false, unique = true)
+	private String email;
+	
+	private boolean isDeleted;
+	
+	public boolean getIsDeleted() {
+		return this.isDeleted;
+	}
+	
+	@CreatedDate
+	@Column(nullable = false)
+	private LocalDateTime createdDate;
+
+	@Builder
+	public Member(String memberName, String password, String email, boolean isDeleted) {
+		this.memberName = memberName;
+		this.password = password;
+		this.email = email;
+		this.isDeleted = isDeleted;
+	}
+	
+}

--- a/board/src/main/java/com/jk/board/repository/MemberRepository.java
+++ b/board/src/main/java/com/jk/board/repository/MemberRepository.java
@@ -1,0 +1,9 @@
+package com.jk.board.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.jk.board.entity.Member;
+
+public interface MemberRepository extends JpaRepository<Member, Long>{
+
+}

--- a/board/src/main/java/com/jk/board/service/MemberService.java
+++ b/board/src/main/java/com/jk/board/service/MemberService.java
@@ -1,0 +1,31 @@
+package com.jk.board.service;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.jk.board.dto.MemberRequest;
+import com.jk.board.entity.Member;
+import com.jk.board.repository.MemberRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class MemberService {
+
+	private final MemberRepository memberRepository;
+	private final PasswordEncoder passwordEncoder;
+	
+	public Long join(final MemberRequest memberRequest) {
+		Member member = Member.builder()
+							  .memberName(memberRequest.getMemberName())
+							  .password(passwordEncoder.encode(memberRequest.getPassword()))
+							  .email(memberRequest.getEmail())
+							  .isDeleted(memberRequest.getIsDeleted())
+							  .build();
+		
+		return memberRepository.save(member).getId();
+	}
+}

--- a/board/src/main/resources/application.properties
+++ b/board/src/main/resources/application.properties
@@ -7,6 +7,7 @@ spring.jpa.properties.hibernate.show_sql=true
 spring.jpa.properties.hibernate.format_sql=true
 logging.level.org.hibernate.SQL=DEBUG
 logging.level.org.hibernate.type.descriptor.sql=trace
+logging.level.org.springframework.security=DEBUG
 spring.jpa.hibernate.ddl-auto=none
 
 


### PR DESCRIPTION
##기능 추가 사항
 ### Member Entity
  - Member Entity를 추가했습니다. Member API Controller
  - Member API Controller를 추가했습니다.
  - 회원을 저장하는 API인 create 메서드를 추가했습니다.
 ### Member Repository
  - Member Repository를 추가했습니다.
 ### Member Request DTO
  - Member Request DTO를 추가했습니다.
 ### Member Service
  - 회원을 저장하는 메서드인 join을 추가했습니다. 
  ### Security Configuration
  - 필터를 처리하기 위해 filterChain 메서드를 추가했습니다.
    - deprecated 된 메서드들이 있어서 추후에 다른 방법으로 CSRF( Cross-Site Request Forgery) 문제를 처리해야할 것 같습니다.
  - 비밀번호 보안을 여러 객체로 처리하면 같지 않습니다. 그러므로 스프링 빈으로 등록해 싱글톤으로 처리했습니다.

## 테스트 환경
 - **API 테스트 환경**

## 기타 추가 사항
 ### application.properties
  - Spring Security 디버깅을 위한 로그를 추가했습니다. 
 ### build.gradle
  - Spring Security를 사용하기 위한 의존성을 추가했습니다.
  - 더 이상 사용하지 않는 MyBatis 의존성을 삭제했습니다.